### PR TITLE
Modifed the local.css file so that the Hangul example in the normaliz…

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta content="text/html; charset=utf-8" http-equiv="content-type">
     <title>Character Model for the World Wide Web: String Matching and Searching</title>
     <!-- local styles. Includes the styles from http://www.w3.org/International/docs/styleguide -->
-	<link rel="stylesheet" href="local.css" type="text/css" />
+    <link rel="stylesheet" href="local.css" type="text/css">
     <script src="http://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
     <script class="remove">
       var respecConfig = {
@@ -113,14 +113,29 @@
     </section>
     <section id="sotd">
       <div class="note">
-        <p>This version of the document represents a significant change from the <a href="http://www.w3.org/TR/2012/WD-charmod-norm-20120501/">earlier editions</a>. Much of the content is changed and the recommendations are significantly altered. This fact is reflected in a change to the name of the document from "Character Model: Normalization".</p>
+        <p>This version of the document represents a significant change from the
+          <a href="http://www.w3.org/TR/2012/WD-charmod-norm-20120501/">earlier
+            editions</a>. Much of the content is changed and the recommendations
+          are significantly altered. This fact is reflected in a change to the
+          name of the document from "Character Model: Normalization".</p>
       </div>
-    <div class="note">
-    <p data-lang="en" style="font-weight: bold; font-size: 120%">Sending comments on this document</p>
-  	<p data-lang="en">If you wish to make comments regarding this document, please raise them as <a href="https://github.com/w3c/charmod-norm/issues" style="font-size: 120%;">github issues</a> against the <a href="http://www.w3.org/TR/2015/WD-charmod-norm-20150721/" style="font-size: 120%">latest dated version in /TR</a>. Only send comments by email if you are unable to raise issues on github (see links below).   All comments are welcome.</p>
-  	<p data-lang="en">To make it easier to track comments, please raise separate issues or emails for each comment, and point to the section you are commenting on&nbsp; using  a URL for the dated version of the document.</p>
-    </div>
-  </section>
+      <div class="note">
+        <p data-lang="en" style="font-weight: bold; font-size: 120%">Sending
+          comments on this document</p>
+        <p data-lang="en">If you wish to make comments regarding this document,
+          please raise them as <a href="https://github.com/w3c/charmod-norm/issues"
+
+            style="font-size: 120%;">github issues</a> against the <a href="http://www.w3.org/TR/2015/WD-charmod-norm-20150721/"
+
+            style="font-size: 120%">latest dated version in /TR</a>. Only send
+          comments by email if you are unable to raise issues on github (see
+          links below). All comments are welcome.</p>
+        <p data-lang="en">To make it easier to track comments, please raise
+          separate issues or emails for each comment, and point to the section
+          you are commenting on&nbsp; using a URL for the dated version of the
+          document.</p>
+      </div>
+    </section>
     <section id="intro">
       <h2>Introduction</h2>
       <section id="goals">
@@ -137,7 +152,7 @@
           concepts in that document are important to being able to understand
           and apply this document successfully.</p>
         <p>This part of the Character Model for the World Wide Web covers string
-          matching&mdash;the process by which a specification or implementation
+          matching—the process by which a specification or implementation
           defines whether two string values are the same or different from one
           another. It describes the ways in which texts that are semantically
           equivalent can be encoded differently and the impact this has on
@@ -196,11 +211,11 @@
           addressed in this specification.</p>
         <p>At the core of the character model is the Universal Character Set
           (UCS), defined jointly by the <cite>Unicode Standard</cite>
-          [[!UNICODE]] and ISO/IEC 10646 [[!ISO10646]]. In this document, <dfn>Unicode</dfn> is used as a synonym for
-          the Universal Character Set. A successful character model allows Web
-          documents authored in the world's writing systems, scripts, and
-          languages (and on different platforms) to be exchanged, read, and
-          searched by the Web's users around the world.</p>
+          [[!UNICODE]] and ISO/IEC 10646 [[!ISO10646]]. In this document, <dfn>Unicode</dfn>
+          is used as a synonym for the Universal Character Set. A successful
+          character model allows Web documents authored in the world's writing
+          systems, scripts, and languages (and on different platforms) to be
+          exchanged, read, and searched by the Web's users around the world.</p>
         <p>The first few chapters of the <cite>Unicode Standard</cite>
           [[!UNICODE]] provide useful background reading.</p>
         <p>For information about the requirements that informed the development
@@ -219,37 +234,48 @@
         <p>Unicode code points are denoted as <code class="kw" translate="no">U+hhhh</code>,
           where <code class="kw" translate="no">hhhh</code> is a sequence of at
           least four, and at most six hexadecimal digits. For example, the
-          character <span class="qchar">€</span> <span class="uname" translate="no">EURO SIGN</span>
-          has the code point <span class="uname" translate="no">U+20AC</span>.</p>
+          character <span class="qchar">€</span> <span class="uname" translate="no">EURO
+            SIGN</span> has the code point <span class="uname" translate="no">U+20AC</span>.</p>
         <p>Some characters that are used in the various examples might not
           appear as intended unless you have the appropriate font. Care has been
           taken to ensure that the examples nevertheless remain understandable.</p>
-        <p>A <dfn data-lt="legacy character encoding|legacy character encodings">legacy character encoding</dfn> is a character encoding not based on the Unicode
-          character set.</p>
-        <p>A <dfn lang-lt="grapheme|graphemes">grapheme</dfn> is
-          a sequence of one or more Unicode characters that form a single
-          user-perceived "character". <cite>Unicode Standard Annex #29: Text
-            Segmentation</cite> [[!UTR29]] defines a unit called the <dfn>grapheme cluster</dfn>, which roughly corresponds to the user's perception of
-          where the character boundaries occur in a visually rendered text, in
-          constrast to the Unicode code points (characters) used to encode the
-          text in a string. (A discussion of grapheme clusters is also given at
-          the end of Section 2.10 of the <cite>Unicode Standard</cite>,
-          [[!UNICODE]].)</p>
-        <p>What Unicode actually defines is <strong>default</strong> grapheme
-          clustering: some languages require tailoring to this default. For
-          example, a Slovak user might wish to treat the default pair of
-          grapheme clusters "ch" as a single grapheme cluster. Note that the
-          interaction between the language of string content and the end-user's
-          preferences might be complex. References to <em>grapheme</em> in this
-          document refer to default grapheme clusters unless tailoring of the
-          grapheme clusters is called out. </p>
-        <p><dfn>Natural language content</dfn>
-          refers to the language-bearing content in a document and <b>not</b>
-          to any of the surrounding markup or identifiers that form part of the
-          document structure. You can think of it as the actual "content" of the
-          document or the "message" in a given protocol. Note that the natural
-          language content can include items such as the document title ("Much
-          Ado About Nothing") as well as prose content within the document.</p>
+        <p>A <dfn data-lt="legacy character encoding|legacy character encodings">legacy
+            character encoding</dfn> is a character encoding not based on the
+          Unicode character set.</p>
+        <p>A <dfn lang-lt="grapheme|graphemes">grapheme</dfn> is a sequence of
+          one or more Unicode characters in a visual representation of some text
+          that a typical user would perceive as being a single unit (<q>character</q>).
+          Graphemes are important for a number of text operations such as
+          sorting or text selection, so it is necessary to be able to compute
+          the boundaries between each user-perceived character. Unicode defines
+          the default mechanism for computing graphemes in <cite>Unicode
+            Standard Annex #29: Text Segmentation</cite>[[!UTR29]] and calls
+          this approximation a <dfn>grapheme cluster</dfn>. There are two types
+          of default grapheme cluster defined. Unless otherwise noted, grapheme
+          cluster in this document refers to an extended default grapheme
+          cluster. (A discussion of grapheme clusters is also given at the end
+          of Section 2.10 of the <cite>Unicode Standard</cite>, [[!UNICODE]].)</p>
+        <p>Because different languages have different needs, grapheme clusters
+          can also sometimes require tailoring. For example, a Slovak user might
+          wish to treat the default pair of grapheme clusters "ch" as a single
+          grapheme cluster. Note that the interaction between the language of
+          string content and the end-user's preferences might be complex.</p>
+        <aside class="example"><p>The Hindi word for Unicode <q>यूनिकोड</q> is composed of a
+          sequence of seven Unicode characters from the Devanagari script (<span
+          class="uname" translate="no">U+092F U+0942 U+0928 U+093F U+0915
+          U+094B U+0921</span>). However, most users would identify this word
+          as containing four units of text&mdash;यू, नि, को, and ड. Each of the first
+          three graphemes consists of two characters: a syllable and a modifying
+          vowel character. So the word contains seven Unicode characters, but
+          only four graphemes.</p></aside>
+
+        <p><dfn>Natural language content</dfn> refers to the language-bearing
+          content in a document and <b>not</b> to any of the surrounding markup
+          or identifiers that form part of the document structure. You can think
+          of it as the actual "content" of the document or the "message" in a
+          given protocol. Note that the natural language content can include
+          items such as the document title as well as prose content within the
+          document.</p>
         <p><dfn id="def_markup">Markup</dfn> is any text in a document format or
           protocol that belongs to the structure of the format or protocol. This
           definition can include values that are not typically thought of as
@@ -272,23 +298,23 @@
             element called <code class="kw">&lt;muffin&gt;</code>, <span class="qterm">muffin</span>
             is a part of the markup.</p>
         </aside>
-        <p>A <dfn data-lt="resource|resources">resource</dfn> is a given document, file, or
-          protocol "message" which includes both the <a>natural
+        <p>A <dfn data-lt="resource|resources">resource</dfn> is a given
+          document, file, or protocol "message" which includes both the <a>natural
             language content</a> as well as the <a href="#def_markup" class="termref">markup</a>
           such as identifiers surrounding or containing it. For example, in an
           HTML document that also has some CSS and a few <code class="kw" translate="no">script</code>
           tags with embedded JavaScript, the entire HTML document, considered as
           a file, is the resource.</p>
-        <p>A <dfn>vocabulary</dfn> provides the list of
+        <p>A <dfn id="def_vocabulary">vocabulary</dfn> provides the list of
           reserved names as well as the set of rules and specifications
           controlling how user values (such as identifiers) can be assigned in a
           format or protocol. This can include restrictions on range, order, or
           type of characters that can appear in different places. For example,
-          HTML defines the names of its elements and attributes, which defines
-          the "vocabulary" of HTML markup. ECMAScript restricts the range of
-          characters that can appear at the start or in the body of an
-          identifier or variable name (while different rules apply to the values
-          of, say, string literals).</p>
+          HTML defines the names of its elements and attributes, as well as
+          enumerated attribute values, which defines the "vocabulary" of HTML
+          markup. ECMAScript restricts the range of characters that can appear
+          at the start or in the body of an identifier or variable name (while
+          different rules apply to the values of, say, string literals).</p>
         <div class="exampleBox" id="Figure1">
           <h2>Figure 1: Terminology examples</h2>
           <div style="border-style: solid; border-width:3px; padding-left: 50px; padding-right: 50px; padding-top: 10px; width: 80%">
@@ -315,11 +341,9 @@
           </div>
           <p>Everything inside the black rectangle (that is, in this HTML file)
             is part of the resource.</p>
-          <p><a>Markup</a> is shown in a <span class="markup">monospaced
-              font</span>.</p>
-          <p><a>Natural language content</a> is
-            shown in a <span class="shakespeare">bold blue font with a gray
-              background</span>.</p>
+          <p><a>Markup</a> is shown in a <span class="markup">monospaced font</span>.</p>
+          <p><a>Natural language content</a> is shown in a <span class="shakespeare">bold
+              blue font with a gray background</span>.</p>
           <p>User values are shown in <span class="userValue">italics</span>.</p>
           <p class="ednote">still need to mark up vocabulary</p>
           <p>All of the text above (all text in a text file) makes up a
@@ -329,7 +353,8 @@
             orange rectangles). It's also possible that a resource will contain
             <em>no</em> markup and consist solely of natural language content:
             for example, a plain text file with a soliloquy from <cite>Hamlet</cite>
-            in it. Notice too that the HTML entity <span class="uname" translate="no">&amp;#x2019;</span> appears in the natural language content and belongs to both the
+            in it. Notice too that the HTML entity <span class="uname" translate="no">&amp;#x2019;</span>
+            appears in the natural language content and belongs to both the
             natural language content and the markup in this resource.</p>
         </div>
       </section>
@@ -384,14 +409,14 @@
       <h2>The String Matching Problem</h2>
       <p>The Web is primarily made up of document formats and protocols based on
         character data. These formats or protocols can be viewed as a set of
-        text files (<a data-lt="resource">resources</a>) that
-        include some form of structural markup. Processing such markup or
-        document data requires string-based operations such as matching,
-        indexing, searching, sorting, regular expression matching, and so forth.
-        As a result, the Web is sensitive to the different ways in which text
-        might be represented in a document. Failing to consider the different
-        ways in which the same text can be represented can confuse users or
-        cause unexpected or frustrating results.</p>
+        text files (<a data-lt="resource">resources</a>) that include some form
+        of structural markup. Processing such markup or document data requires
+        string-based operations such as matching, indexing, searching, sorting,
+        regular expression matching, and so forth. As a result, the Web is
+        sensitive to the different ways in which text might be represented in a
+        document. Failing to consider the different ways in which the same text
+        can be represented can confuse users or cause unexpected or frustrating
+        results.</p>
       <section id="definitionCaseFolding">
         <h3>Case Folding</h3>
         <p>Some scripts and writing systems make a distinction between UPPER,
@@ -419,9 +444,8 @@
         <p>The <code class="kw" translate="no">SPAN</code> in the stylesheet
           matches the <code class="kw" translate="no">span</code> element in
           the document, even though one is uppercase and the other is not.</p>
-        <p><dfn>Case folding</dfn> is
-          the process of making two texts identical which differ in case but are
-          otherwise "the same".</p>
+        <p><dfn>Case folding</dfn> is the process of making two texts identical
+          which differ in case but are otherwise "the same".</p>
         <p>Case folding might, at first, appear simple. However there are
           variations that need to be considered when treating the full range of
           Unicode in diverse languages. For more information, <cite>Unicode</cite>
@@ -444,35 +468,33 @@
             case, this word appears like this: <span class="qterm">DİYARBAKIR</span>.
             Notice that the ASCII letter <span class="qchar">i</span> maps to <span
 
-              class="uname" translate="no">U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE</span>,
-            while the letter <span class="qchar">ı</span> (<span class="uname" translate="no">U+0131
-              LATIN SMALL LETTER DOTLESS I</span>) maps to the ASCII uppercase <span
+              class="uname" translate="no">U+0130 LATIN CAPITAL LETTER I WITH
+              DOT ABOVE</span>, while the letter <span class="qchar">ı</span> (<span
 
-              class="qchar">I</span>. </p>
+              class="uname" translate="no">U+0131 LATIN SMALL LETTER DOTLESS I</span>)
+            maps to the ASCII uppercase <span class="qchar">I</span>. </p>
         </aside>
         There are four types of casefold matching defined for the purposes of
         string identity matching in document formats or protocols:
-        <p><dfn data-lt="case sensitive">Case sensitive
-            matching</dfn>: code points are compared directly with no case
-          folding.</p>
-        <p>Sometimes case can vary in a way that is not semantically
-          meaningful or is not fully under the user's control. This is
-          particularly true when <a href="#searching">searching</a> a document,
-          but also applies when defining rules for matching user- or
-          content-generated values, such as identifiers. In these situations,
-          case-<em>in</em>sensitive matching might be desirable instead.</p>
-        <p>When defining a <a>vocabulary</a>, one important
-          consideration is whether the values are restricted to the ASCII subset
-          of Unicode or if the vocabulary permits the use of characters (such as
-          accents on Latin letters or a broad range of Unicode including
-          non-Latin scripts) that potentially have more complex case folding
-          requirements.</p>
-        <p><dfn data-lt="ASCII case-insensitive">ASCII
-            case-insensitive matching</dfn> compares a sequence of code points
-          as if all ASCII code points in the range 0x41 to 0x5A (A to Z) were
-          mapped to the corresponding code points in the range 0x61 to 0x7A (a
-          to z). When a vocabulary is itself constrained to ASCII, ASCII
-          case-insensitive matching can be required. </p>
+        <p><dfn data-lt="case sensitive">Case sensitive matching</dfn>: code
+          points are compared directly with no case folding.</p>
+        <p>Sometimes case can vary in a way that is not semantically meaningful
+          or is not fully under the user's control. This is particularly true
+          when <a href="#searching">searching</a> a document, but also applies
+          when defining rules for matching user- or content-generated values,
+          such as identifiers. In these situations, case-<em>in</em>sensitive
+          matching might be desirable instead.</p>
+        <p>When defining a <a>vocabulary</a>, one important consideration is
+          whether the values are restricted to the ASCII subset of Unicode or if
+          the vocabulary permits the use of characters (such as accents on Latin
+          letters or a broad range of Unicode including non-Latin scripts) that
+          potentially have more complex case folding requirements.</p>
+        <p><dfn data-lt="ASCII case-insensitive">ASCII case-insensitive matching</dfn>
+          compares a sequence of code points as if all ASCII code points in the
+          range 0x41 to 0x5A (A to Z) were mapped to the corresponding code
+          points in the range 0x61 to 0x7A (a to z). When a vocabulary is itself
+          constrained to ASCII, ASCII case-insensitive matching can be required.
+        </p>
         <p id="uci"><dfn data-lt="Unicode case-insensitive">Unicode
             case-insensitive matching</dfn> compares a sequence of code points
           as if one of the Unicode-defined language-independent default case
@@ -484,12 +506,16 @@
           developers and implementers. We should also add that the case folding
           algorithms are somewhat different from the simple upper and lower case
           conversions.</p>
-          <ul>
-        <li><p><dfn>Unicode C+F</dfn> (Unicode Full Casefold). This
-          case-fold uses the "common" plus the "full" case-fold.</p></li>
-        <li><p><dfn>Unicode C+S</dfn> (Unicode Simple Casefold).
-          Unicode also defines a "common" plus "simple" case-fold.</p></li>
-          </ul>
+        <ul>
+          <li>
+            <p><dfn>Unicode C+F</dfn> (Unicode Full Casefold). This case-fold
+              uses the "common" plus the "full" case-fold.</p>
+          </li>
+          <li>
+            <p><dfn>Unicode C+S</dfn> (Unicode Simple Casefold). Unicode also
+              defines a "common" plus "simple" case-fold.</p>
+          </li>
+        </ul>
         <p><dfn>Language-sensitive case-sensitive matching</dfn> is useful in
           the rare case where a document format or protocol contains information
           about the language of the markup and where language-sensitive case
@@ -503,49 +529,62 @@
         <h3>Unicode Normalization</h3>
         <p>Other kinds of variations can occur in Unicode text: some <a data-lt="grapheme">graphemes</a>
           can be represented by several different Unicode code point sequences.
-          Consider the character <span class="uname" translate="no">Ǻ U+01FA LATIN LETTER
-            CAPITAL A WITH RING ABOVE AND ACUTE</span>. Here are some of the
-          different character sequences that an HTML document could use to
-          represent this character:</p>
+          Consider the character <span class="uname" translate="no">Ǻ U+01FA
+            LATIN LETTER CAPITAL A WITH RING ABOVE AND ACUTE</span>. Here are
+          some of the different character sequences that an HTML document could
+          use to represent this character:</p>
         <ul class="dropExampleList">
-          <li class="dropExampleItem"><span class="dropExample">&#x01FA;</span> <span class="uname" translate="no">U+01FA</span>— A "precomposed" character.</li>
-          <li class="dropExampleItem"><span class="dropExample">A&#x030A;&#x0301;</span><span class="uname" translate="no">A + U+030A + U+0301</span>— A <span
+          <li class="dropExampleItem"><span class="dropExample">Ǻ</span> <span
 
-              class="qterm">base</span> letter <span class="qchar">A</span>
+              class="uname" translate="no">U+01FA</span>— A "precomposed"
+            character.</li>
+          <li class="dropExampleItem"><span class="dropExample">Ǻ</span><span
+
+              class="uname" translate="no">A&nbsp;+&nbsp;U+030A&nbsp;+&nbsp;U+0301</span>—
+            A <span class="qterm">base</span> letter <span class="qchar">A</span>
             followed by two combining marks (<span class="uname" translate="no">U+030A
               COMBINING RING ABOVE</span> and <span class="uname" translate="no">U+0301
               COMBINING ACUTE ACCENT</span>)</li>
-          <li class="dropExampleItem"><span class="dropExample">&#x00C5;&#x0301;</span><span class="uname" translate="no">U+00C5
-              + U+0301</span>—An accented letter (<span class="uname" translate="no">U+00C5
-              LATIN CAPITAL LETTER A WITH RING ABOVE</span>) followed by a
-            combining accent (<span class="uname" translate="no">U+0301 COMBINING ACUTE ACCENT</span>)</li>
-          <li class="dropExampleItem"><span class="dropExample">&#x212B;&#x0301;</span><span class="uname" translate="no">U+212B
-              + U+0301</span>—A compatibility character (<span class="uname" translate="no">U+212B
-              ANGSTROM SIGN</span>) followed by a combining accent (<span class="uname" translate="no">U+0301
+          <li class="dropExampleItem"><span class="dropExample">Ǻ</span><span class="uname"
+
+              translate="no">U+00C5 + U+0301</span>—An accented letter (<span class="uname"
+
+              translate="no">U+00C5 LATIN CAPITAL LETTER A WITH RING ABOVE</span>)
+            followed by a combining accent (<span class="uname" translate="no">U+0301
               COMBINING ACUTE ACCENT</span>)</li>
-          <li class="dropExampleItem"><span class="dropExample">&#xFF21;&#x030A;&#x0301;</span><span class="uname" translate="no">U+FF21 + U+030A + U+0301</span>— A compatibility
-            character <span class="uname" translate="no">U+FF21 FULLWIDTH LATIN LETTER CAPITAL
-              A</span>) followed by two combining marks (<span class="uname" translate="no">U+030A
-              COMBINING RING ABOVE</span> and <span class="uname" translate="no">U+0301
+          <li class="dropExampleItem"><span class="dropExample">Ǻ</span><span class="uname"
+
+              translate="no">U+212B + U+0301</span>—A compatibility character (<span
+
+              class="uname" translate="no">U+212B ANGSTROM SIGN</span>) followed
+            by a combining accent (<span class="uname" translate="no">U+0301
+              COMBINING ACUTE ACCENT</span>)</li>
+          <li class="dropExampleItem"><span class="dropExample">Ａ̊́</span><span
+
+              class="uname" translate="no">U+FF21 + U+030A + U+0301</span>— A
+            compatibility character <span class="uname" translate="no">U+FF21
+              FULLWIDTH LATIN LETTER CAPITAL A</span>) followed by two combining
+            marks (<span class="uname" translate="no">U+030A COMBINING RING
+              ABOVE</span> and <span class="uname" translate="no">U+0301
               COMBINING ACUTE ACCENT</span>)</li>
         </ul>
         <p>Each of the above strings contains the same apparent <span class="quote">meaning
             </span>as <span class="qchar">Ǻ</span> (<span class="uname">U+01FA
-          as <span class="qchar">Ǻ</span> (<span class="uname" translate="no">U+01FA LATIN
-            CAPITAL LETTER A WITH RING ABOVE AND ACUTE</span>), but each one is
-          encoded slightly differently. More variations are possible, but are
-          omitted for brevity. </p>
+            as <span class="qchar">Ǻ</span> (<span class="uname" translate="no">U+01FA
+              LATIN CAPITAL LETTER A WITH RING ABOVE AND ACUTE</span>), but each
+            one is encoded slightly differently. More variations are possible,
+            but are omitted for brevity. </span></p>
         <p>Because applications need to find the semantic equivalence in texts
           that use different code point sequences, Unicode defines a means of
           making two semantically equivalent texts identical: the Unicode
           Normalization Forms [[!UAX15]].</p>
-        <p><a data-lt="resource">Resources</a> are often susceptible to the effects
-          of these variations because their specifications and implementations
-          on the Web do not require Unicode Normalization of the text, nor do
-          they take into consideration the string matching algorithms used when
-          processing the markup and content later. For this reason, content
-          developers need to ensure that they have provided a consistent
-          representation in order to avoid problems later.</p>
+        <p><a data-lt="resource">Resources</a> are often susceptible to the
+          effects of these variations because their specifications and
+          implementations on the Web do not require Unicode Normalization of the
+          text, nor do they take into consideration the string matching
+          algorithms used when processing the markup and content later. For this
+          reason, content developers need to ensure that they have provided a
+          consistent representation in order to avoid problems later.</p>
         <p>However, it can be difficult for users to assure that a given <a data-lt="resource">resource</a>
           or set of resources uses a consistent textual representation because
           the differences are usually not visible when viewed as text. Tools and
@@ -557,78 +596,88 @@
           that spring from invisible differences in their source documents. For
           example, the W3C Validator warns when an HTML document is not fully in
           Unicode Normalization Form C.</p>
-          
-          <section id="canonical_compatibility">
+        <section id="canonical_compatibility">
           <h4>Canonical vs. Compatibility Equivalence</h4>
           <p>Unicode defines two types of equivalence between characters: <em>canonical
               equivalence</em> and <em>compatibility equivalence</em>.</p>
-          <p><dfn>Canonical equivalence</dfn> is a
-            fundamental equivalency between Unicode characters or sequences of
-            Unicode characters that represent the same abstract character. When
-            correctly displayed, these should always have the same visual
-            appearance and behavior. Generally speaking, two canonically
-            equivalent Unicode texts should be considered to be identical as
-            text. Canonical decomposition removes these primary distinctions
-            between two texts.</p>
+          <p><dfn>Canonical equivalence</dfn> is a fundamental equivalency
+            between Unicode characters or sequences of Unicode characters that
+            represent the same abstract character. When correctly displayed,
+            these should always have the same visual appearance and behavior.
+            Generally speaking, two canonically equivalent Unicode texts should
+            be considered to be identical as text. Canonical decomposition
+            removes these primary distinctions between two texts.</p>
           <p>Examples of canonical equivalence defined by Unicode include:</p>
           <ul class="dropExampleList">
-            <li class="dropExampleItem"><span class="dropExample">Ç<span style="font-size:75%"> vs.</span>C&#x0327;</span>
-              <em>Precomposed versus combining sequences.</em> Some characters
-              can be composed from a base character followed by one or more
-              combining characters. The same characters are sometimes also
-              encoded as a distinct "precomposed" character. In this example,
-              the character <span class="qchar">Ç</span> <span class="uname" translate="no">U+00C7</span>
-              is canonically equivalent to the base character <span class="qchar">C</span>
-              <span class="uname" translate="no">U+0043</span> followed by the combining
-              cedilla character <span class="qchar">̧</span> <span class="uname" translate="no">U+0327</span>.
-              Such equivalence can extend to characters with multiple combining
-              marks.</li>
-            <li class="dropExampleItem"><span class="dropExample">q&#x0307;&#x0323;<span style="font-size:75%"> vs.</span>q&#x0323;&#x0307;</span>
-              <em>Order of combining marks.</em> When a base character is
-              modified by multiple combining marks, the order of the combining
-              marks might not represent a distinct character. Here the sequence
-              <span class="qterm">q&#x0307;&#x0323;</span>(<span class="uname" translate="no">U+0071 U+0323
-                U+0307</span>) and <span class="qterm">q&#x0323;&#x0307;</span>(<span class="uname" translate="no">U+0071
+            <li class="dropExampleItem"><span class="dropExample">Ç<span style="font-size:75%">
+                  vs.</span>Ç</span> <em>Precomposed versus combining
+                sequences.</em> Some characters can be composed from a base
+              character followed by one or more combining characters. The same
+              characters are sometimes also encoded as a distinct "precomposed"
+              character. In this example, the character <span class="qchar">Ç</span>
+              <span class="uname" translate="no">U+00C7</span> is canonically
+              equivalent to the base character <span class="qchar">C</span> <span
+
+                class="uname" translate="no">U+0043</span> followed by the
+              combining cedilla character <span class="qchar">̧</span> <span class="uname"
+
+                translate="no">U+0327</span>. Such equivalence can extend to
+              characters with multiple combining marks.</li>
+            <li class="dropExampleItem"><span class="dropExample">q̣̇<span style="font-size:75%">
+                  vs.</span>q̣̇</span> <em>Order of combining marks.</em> When
+              a base character is modified by multiple combining marks, the
+              order of the combining marks might not represent a distinct
+              character. Here the sequence <span class="qterm">q̣̇</span>(<span
+
+                class="uname" translate="no">U+0071 U+0323 U+0307</span>) and <span
+
+                class="qterm">q̣̇</span>(<span class="uname" translate="no">U+0071
                 U+0307 U+0323</span>) are equivalent, even though the combining
               marks are in a different order. Note that this example is chosen
               carefully: the dot-above character and dot-below character are on
               opposite "sides" of the base character. The order of combining
               diacritics on the same side have a positional meaning.</li>
-            <li class="dropExampleItem"><span class="dropExample">&#x2126;<span style="font-size:75%"> vs.</span>Ω</span>
-              <em>Singleton mappings.</em> These result from the need to
-              separately encode otherwise equivalent characters to support
-              legacy character encodings. In this example, the Ohm symbol <span
+            <li class="dropExampleItem"><span class="dropExample">Ω<span style="font-size:75%">
+                  vs.</span>Ω</span> <em>Singleton mappings.</em> These result
+              from the need to separately encode otherwise equivalent characters
+              to support legacy character encodings. In this example, the Ohm
+              symbol <span class="qchar">Ω</span> <span class="uname" translate="no">U+2126</span>
+              is canonically equivalent (and identical in appearance) to the
+              Greek letter Omega <span class="qchar">Ω</span> <span class="uname"
 
-                class="qchar">Ω</span> <span class="uname" translate="no">U+2126</span> is
-              canonically equivalent (and identical in appearance) to the Greek
-              letter Omega <span class="qchar">Ω</span> <span class="uname" translate="no">U+03A9</span>.</li>
-            <li class="dropExampleItem"><span class="dropExample">가<span style="font-size:75%"> vs.</span>&#x1100;&#x1161;</span>
-              <em>Hangul.</em> The Hangul script is used to write the Korean
-              language. This script is constructed logically, with each syllable
-              being a roughly-square <a>grapheme</a>
+                translate="no">U+03A9</span>.</li>
+            <li class="dropExampleItem"><span class="dropExample">가<span style="font-size:75%">
+                  vs.</span>가</span> <em>Hangul.</em> The Hangul script is
+              used to write the Korean language. This script is constructed
+              logically, with each syllable being a roughly-square <a>grapheme</a>
               formed from specific sub-parts that represent consonants and
               vowels. These specific sub-parts, called <em>jamo</em>, are
-              encoded in Unicode. So too are the precomposed syllables. Thus
-              the syllable <span class="qchar">가</span>&nbsp; <span class="uname" translate="no">U+AC00</span>
-              is canonically equivalent to its constituent <em>jamo</em>
-              characters <span class="qchar">ᄀ</span>&nbsp;<span class="uname" translate="no">U+1100</span> and <span class="qchar">ᅡ</span>&nbsp;<span class="uname" translate="no">U+1161</span>.</li>
+              encoded in Unicode. So too are the precomposed syllables. Thus the
+              syllable <span class="qchar">가</span>&nbsp; <span class="uname"
+
+                translate="no">U+AC00</span> is canonically equivalent to its
+              constituent <em>jamo</em> characters <span class="qchar">ᄀ</span>&nbsp;<span
+
+                class="uname" translate="no">U+1100</span> and <span class="qchar">ᅡ</span>&nbsp;<span
+
+                class="uname" translate="no">U+1161</span>.</li>
           </ul>
-          <p><dfn>Compatibility equivalence</dfn>
-            is a weaker equivalence between characters or sequences of
-            characters that represent the same abstract character, but may have
-            a different visual appearance or behavior. Generally a compatibility
-            decomposition removes formatting variations, such as superscript,
-            subscript, rotated, circled, and so forth, but other variations also
-            occur. In many cases, characters with compatibility decompositions
-            represent a distinction of a semantic nature; replacing the use of
-            distinct characters with their compatibility decomposition can
-            therefore cause problems and texts that are equivalent after
-            compatibility decomposition often were not perceived as being
-            identical beforehand and usually should not be treated as equivalent
-            by a formal language.</p>
+          <p><dfn>Compatibility equivalence</dfn> is a weaker equivalence
+            between characters or sequences of characters that represent the
+            same abstract character, but may have a different visual appearance
+            or behavior. Generally a compatibility decomposition removes
+            formatting variations, such as superscript, subscript, rotated,
+            circled, and so forth, but other variations also occur. In many
+            cases, characters with compatibility decompositions represent a
+            distinction of a semantic nature; replacing the use of distinct
+            characters with their compatibility decomposition can therefore
+            cause problems and texts that are equivalent after compatibility
+            decomposition often were not perceived as being identical beforehand
+            and usually should not be treated as equivalent by a formal
+            language.</p>
           <p>The following table illustrates various kinds of compatibility
             equivalence in Unicode:</p>
-          <figure> 
+          <figure>
             <div style="width:80%; margin-left:10%;margin-right:10%; font-size:18px;">
               <table>
                 <thead>
@@ -649,11 +698,12 @@
                       in breaking or joining rules, such as the difference
                       between a <span class="qterm">normal</span> and a
                       non-breaking space.</td>
-                    <td style="text-align: center" colspan="4"><span
-                        class="uname" translate="no">U+00A0 NON-BREAKING SPACE</span></td>
+                    <td style="text-align: center" colspan="4"><span class="uname"
+
+                        translate="no">U+00A0 NON-BREAKING SPACE</span></td>
                   </tr>
                   <tr>
-                    <td><strong>Presentation forms of Arabic</strong>&mdash;
+                    <td><strong>Presentation forms of Arabic</strong>—
                       characters that encode the specific shapes&nbsp;(initial,
                       medial, final, isolated) needed by visual legacy encodings
                       of the Arabic script.</td>
@@ -669,7 +719,7 @@
                       presentation</td>
                     <td style="text-align: center" colspan="1"> <span class="charSample">①</span></td>
                     <td style="text-align: center" colspan="1"> <span class="charSample">❿</span></td>
-                    <td style="text-align: center" colspan="1"> <span class="charSample">&#x3244;</span></td>
+                    <td style="text-align: center" colspan="1"> <span class="charSample">㉄</span></td>
                     <td style="text-align: center" colspan="1"> <span class="charSample">㊞</span></td>
                   </tr>
                   <tr>
@@ -687,74 +737,75 @@
                     <td><strong>Superscripts/subscripts</strong>—superscript or
                       subscript letters, numbers, and symbols.</td>
                     <td style="text-align: center"> <span class="charSample">⁹</span></td>
-                    <td style="text-align: center"> <span class="charSample">&#x2089;</span></td>
-                    <td style="text-align: center"> <span class="charSample">&#xAA;</span></td>
-                    <td style="text-align: center"> <span class="charSample">&#x208A;</span></td>
+                    <td style="text-align: center"> <span class="charSample">₉</span></td>
+                    <td style="text-align: center"> <span class="charSample">ª</span></td>
+                    <td style="text-align: center"> <span class="charSample">₊</span></td>
                   </tr>
                   <tr>
                     <td><strong><span class="quote">Squared</span> characters</strong>—East
-                      Asian (particularly kana) sequences encoded as a presentation form to
-                      fit in a single ideographic "cell" in text.</td>
+                      Asian (particularly kana) sequences encoded as a
+                      presentation form to fit in a single ideographic "cell" in
+                      text.</td>
                     <td style="text-align: center"> <span class="charSample">㌀</span></td>
-                    <td style="text-align: center"> <span class="charSample">&#x3350;</span></td>
-                    <td style="text-align: center"> <span class="charSample">&#x1F120;</span></td>
-                    <td style="text-align: center"> <span class="charSample">&#x3389;</span></td>
+                    <td style="text-align: center"> <span class="charSample">㍐</span></td>
+                    <td style="text-align: center"> <span class="charSample">🄠</span></td>
+                    <td style="text-align: center"> <span class="charSample">㎉</span></td>
                   </tr>
                   <tr>
-                    <td><strong>Fractions</strong>—precomposed vulgar
-                      fractions, often encoded for compatibility with font glyph
-                      sets.</td>
+                    <td><strong>Fractions</strong>—precomposed vulgar fractions,
+                      often encoded for compatibility with font glyph sets.</td>
                     <td style="text-align: center"> <span class="charSample">¼</span></td>
-                    <td style="text-align: center"> <span class="charSample">&#xBD;</span></td>
-                    <td style="text-align: center"> <span class="charSample">&#x215F;</span></td>
-                    <td style="text-align: center"> <span class="charSample">&#x2189;</span></td>
+                    <td style="text-align: center"> <span class="charSample">½</span></td>
+                    <td style="text-align: center"> <span class="charSample">⅟</span></td>
+                    <td style="text-align: center"> <span class="charSample">↉</span></td>
                   </tr>
                   <tr>
-                    <td><strong>Others</strong>—compatibility
-                      characters encoded for other reasons, generally for compatibility
-                      with legacy character encodings. Many of these characters are simply 
-                      a sequence of characters encoded as a single presentational unit.</td>
+                    <td><strong>Others</strong>—compatibility characters encoded
+                      for other reasons, generally for compatibility with legacy
+                      character encodings. Many of these characters are simply a
+                      sequence of characters encoded as a single presentational
+                      unit.</td>
                     <td style="text-align: center"> <span class="charSample">ǆ</span></td>
-                    <td style="text-align: center"> <span class="charSample">&#x2474;</span></td>
-                    <td style="text-align: center"> <span class="charSample">&#x2488;</span></td>
-                    <td style="text-align: center"> <span class="charSample">&#x2ef3;</span></td>
+                    <td style="text-align: center"> <span class="charSample">⑴</span></td>
+                    <td style="text-align: center"> <span class="charSample">⒈</span></td>
+                    <td style="text-align: center"> <span class="charSample">⻳</span></td>
                   </tr>
                 </tbody>
               </table>
             </div>
-            <figcaption>Compatibility Equivalence</figcaption>
-          </figure>
+            <figcaption>Compatibility Equivalence</figcaption> </figure>
+          <p>In the above table, it is important to note that the characters
+            illustrated are <em>actual Unicode codepoints</em>. They were
+            encoded into Unicode for compatibility with various legacy character
+            encodings. They should not be confused with the normal kinds of
+            presentational processing used on their non-compatibility
+            counterparts. </p>
+          <p>For example, most Arabic-script text uses the characters in the
+            Arabic script block of Unicode (starting at <span class="uname" translate="no">U+0600</span>).
+            The actual glyphs used to display the text are selected using fonts
+            and text processing logic based on the position inside a word
+            (initial, medial, final, or isolated), in a process called
+            "shaping". In the table above, the four presentation forms of the
+            Arabic letter <span class="uname" translate="no">NOON</span> are
+            shown. The characters shown are compatibility characters in the <span
 
-            <p>In the above table, it is important to note that the characters
-              illustrated are <em>actual Unicode codepoints</em>. They were
-              encoded into Unicode for compatibility with various legacy
-              character encodings. They should not be confused with the normal
-              kinds of presentational processing used on their non-compatibility
-              counterparts. </p>
-            <p>For example, most Arabic-script text uses the characters in the              
-            Arabic script block of Unicode (starting at <span class="uname" translate="no">U+0600</span>). The actual glyphs
-              used to display the text are selected using fonts and text processing
-              logic based on the position inside a word (initial, medial, final,
-              or isolated), in a process called "shaping". In the table above,
-              the four presentation forms of the Arabic letter <span class="uname" translate="no">NOON</span> are shown.
-              The characters shown are compatibility characters in the <span class="uname" translate="no">U+FE00</span>
-              block, each of which represents a specific "positional" shape and
-              each of the four code points shown have a compatibility
-              decomposition to the <span class="quote">regular</span> Arabic letter <span class="uname" translate="no">U+0646 NOON</span>.</p>
-            <p>Similarly, the variations in East Asian width and the rotated
-              bracket (for use in vertical text) are encoded as separate code
-              points.</p>
-            <p>In the case of characters with compatibility decompositions, such
-              as those shown above, the <span class="qchar">K</span> Unicode Normalization forms convert
-              the text to the "normal" or "expected" Unicode code point. But the
-              existence of these compatibility characters cannot be taken to
-              imply that similar appearance variations produced in the normal
-              course of text layout and presentation are affected by Unicode
-              Normalization. They are not.</p>
-			</section>
-
-		<section id="composition_decomposition">
-        <h4>Composition vs. Decomposition</h4>
+              class="uname" translate="no">U+FE00</span> block, each of which
+            represents a specific "positional" shape and each of the four code
+            points shown have a compatibility decomposition to the <span class="quote">regular</span>
+            Arabic letter <span class="uname" translate="no">U+0646 NOON</span>.</p>
+          <p>Similarly, the variations in East Asian width and the rotated
+            bracket (for use in vertical text) are encoded as separate code
+            points.</p>
+          <p>In the case of characters with compatibility decompositions, such
+            as those shown above, the <span class="qchar">K</span> Unicode
+            Normalization forms convert the text to the "normal" or "expected"
+            Unicode code point. But the existence of these compatibility
+            characters cannot be taken to imply that similar appearance
+            variations produced in the normal course of text layout and
+            presentation are affected by Unicode Normalization. They are not.</p>
+        </section>
+        <section id="composition_decomposition">
+          <h4>Composition vs. Decomposition</h4>
           <p>These two types of Unicode-defined equivalence are then grouped by
             another pair of variations: "decomposition" and "composition". In
             "decomposition", separable logical parts of a visual character are
@@ -765,7 +816,7 @@
             characters. Note that this does <strong>not</strong> mean that all
             of the combining marks have been removed from the resulting
             normalized text. </p>
-        <div class="note">
+          <div class="note">
             <p>Roughly speaking, <abbr title="Normalization Form C">NFC</abbr>
               is defined such that each combining character sequence (a base
               character followed by one or more combining characters) is
@@ -776,9 +827,8 @@
               precomposed character and if any remaining combining sequence is
               in canonical order.</p>
           </div>
-</section>
-          
-          <section id="normalization_forms">
+        </section>
+        <section id="normalization_forms">
           <h4>Unicode Normalization Forms</h4>
           <p>The Unicode Normalization Forms are named using letter codes, with
             'C' standing for Composition, 'D' for Decomposition, and 'K' for
@@ -787,7 +837,7 @@
             we can finally "normalize" the Unicode texts given in the example
             above. Here are the resulting sequences in each Unicode
             Normalization form for the U+01FA example given earlier: </p>
-          <figure> 
+          <figure>
             <div style="margin-left:5%; margin-right:15%; width:80%; text-align:center;">
               <table>
                 <thead>
@@ -801,70 +851,69 @@
                 </thead>
                 <tbody>
                   <tr>
-                    <td class="b-clear">&#x01FA;<br>
+                    <td class="b-clear">Ǻ<br>
                       <span class="tableSub">U+01FA</span></td>
-                    <td class="b1">&#x01FA;<br>
+                    <td class="b1">Ǻ<br>
                       <span class="tableSub">U+01FA</span></td>
-                    <td class="b2">A&#x030A;&#x0301;<br>
+                    <td class="b2">Ǻ<br>
                       <span class="tableSub">U+0041 U+030A U+0301</span></td>
-                    <td class="b1">&#x01FA;<br>
+                    <td class="b1">Ǻ<br>
                       <span class="tableSub">U+01FA</span></td>
-                    <td class="b2">A&#x030A;&#x0301;<br>
+                    <td class="b2">Ǻ<br>
                       <span class="tableSub">U+0041 U+030A U+0301</span></td>
                   </tr>
                   <tr>
-                    <td class="b-clear">&#x00C5;&#x0301;<br>
+                    <td class="b-clear">Ǻ<br>
                       <span class="tableSub">U+00C5 U+0301</span></td>
-                    <td class="b1">&#x01FA;<br>
+                    <td class="b1">Ǻ<br>
                       <span class="tableSub">U+01FA</span></td>
-                    <td class="b2">A&#x030A;&#x0301;<br>
+                    <td class="b2">Ǻ<br>
                       <span class="tableSub">U+0041 U+030A U+0301</span></td>
-                    <td class="b1">&#x01FA;<br>
+                    <td class="b1">Ǻ<br>
                       <span class="tableSub">U+01FA</span></td>
-                    <td class="b2">A&#x030A;&#x0301;<br>
+                    <td class="b2">Ǻ<br>
                       <span class="tableSub">U+0041 U+030A U+0301</span></td>
                   </tr>
                   <tr>
-                    <td class="b-clear">&#x212B;&#x0301;<br>
+                    <td class="b-clear">Ǻ<br>
                       <span class="tableSub">U+212B U+0301</span></td>
-                    <td class="b1">&#x01FA;<br>
+                    <td class="b1">Ǻ<br>
                       <span class="tableSub">U+01FA</span></td>
-                    <td class="b2">A&#x030A;&#x0301;<br>
+                    <td class="b2">Ǻ<br>
                       <span class="tableSub">U+0041 U+030A U+0301</span></td>
-                    <td class="b1">&#x01FA;<br>
+                    <td class="b1">Ǻ<br>
                       <span class="tableSub">U+01FA</span></td>
-                    <td class="b2">A&#x030A;&#x0301;<br>
+                    <td class="b2">Ǻ<br>
                       <span class="tableSub">U+0041 U+030A U+0301</span></td>
                   </tr>
                   <tr>
-                    <td class="b-clear">A&#x030A;&#x0301;<br>
+                    <td class="b-clear">Ǻ<br>
                       <span class="tableSub">U+0041 U+030A U+0301</span></td>
-                    <td class="b1">&#x01FA;<br>
+                    <td class="b1">Ǻ<br>
                       <span class="tableSub">U+01FA</span></td>
-                    <td class="b2">A&#x030A;&#x0301;<br>
+                    <td class="b2">Ǻ<br>
                       <span class="tableSub"> U+0041 U+030A U+0301</span></td>
-                    <td class="b1">&#x01FA;<br>
+                    <td class="b1">Ǻ<br>
                       <span class="tableSub">U+01FA</span></td>
-                    <td class="b2">A&#x030A;&#x0301;<br>
+                    <td class="b2">Ǻ<br>
                       <span class="tableSub">U+0041 U+030A U+0301</span></td>
                   </tr>
                   <tr>
-                    <td class="b-clear">&#xFF21;&#x030A;&#x0301;<br>
+                    <td class="b-clear">Ａ̊́<br>
                       <span class="tableSub">U+FF21 U+030A U+0301</span></td>
-                    <td class="b3">&#xFF21;&#x030A;&#x0301;<br>
+                    <td class="b3">Ａ̊́<br>
                       <span class="tableSub">U+FF21 U+030A U+0301</span></td>
-                    <td class="b3">&#xFF21;&#x030A;&#x0301;<br>
+                    <td class="b3">Ａ̊́<br>
                       <span class="tableSub"> U+FF21 U+030A U+0301</span></td>
-                    <td class="b1">&#x01FA;<br>
+                    <td class="b1">Ǻ<br>
                       <span class="tableSub">U+01FA</span></td>
-                    <td class="b2">A&#x030A;&#x0301;<br>
+                    <td class="b2">Ǻ<br>
                       <span class="tableSub">U+0041 U+030A U+0301</span></td>
                   </tr>
                 </tbody>
               </table>
             </div>
-            <figcaption>Comparison of Unicode Normalization Forms</figcaption>
-          </figure>
+            <figcaption>Comparison of Unicode Normalization Forms</figcaption> </figure>
           <p>Unicode Normalization reduces these (and other potential sequences
             of escapes representing the same character) to just three possible
             variations. However, Unicode Normalization doesn't remove all
@@ -878,8 +927,8 @@
               actually distinct in Unicode and don't have canonical or
               compatibility decompositions to link them together. For example, <span
 
-                class="qchar">。</span> <span class="uname" translate="no">U+3002 IDEOGRAPHIC
-                FULL STOP</span> is used as a <span class="quote">period</span>
+                class="qchar">。</span> <span class="uname" translate="no">U+3002
+                IDEOGRAPHIC FULL STOP</span> is used as a <span class="quote">period</span>
               at the end of sentences in languages such as Chinese or Japanese.
               However, it is not considered equivalent to the ASCII <span class="quote">period</span>
               character <span class="uname" translate="no">U+002E FULL STOP</span>.</li>
@@ -889,13 +938,14 @@
               be separately handled when comparing text.</li>
             <li>Normalization can remove meaning. For example, the character
               sequence <span class="qterm"><samp>8½</samp></span> (including
-              the character <span class="uname" translate="no">U+00BD VULGAR FRACTION ONE HALF</span>),
-              when normalized using one of the <span class="quote">compatibility</span>
-              normalization forms (that is, NFKD or NFKC), becomes an ASCII
-              character sequence that looks like: <samp>81/2</samp>.</li>
+              the character <span class="uname" translate="no">U+00BD VULGAR
+                FRACTION ONE HALF</span>), when normalized using one of the <span
+
+                class="quote">compatibility</span> normalization forms (that is,
+              NFKD or NFKC), becomes an ASCII character sequence that looks
+              like: <samp>81/2</samp>.</li>
           </ul>
         </section>
-        
       </section>
       <section id="characterEscapes">
         <h3>Character Escapes</h3>
@@ -947,7 +997,7 @@
         <p>A special case is for ZWJ and ZWNJ. These invisible controls
           sometimes affect meaning.</p>
         <p>Examples of these include:</p>
-        <figure> 
+        <figure>
           <table style="width: 100%; border: 1px solid #ddd;">
             <thead>
               <tr>
@@ -988,8 +1038,7 @@
               </tr>
             </tbody>
           </table>
-          <figcaption>Invisible Controls</figcaption>
-        </figure>
+          <figcaption>Invisible Controls</figcaption> </figure>
         <p class="ednote">This section was added and needs further fleshing out.
           The requirement probably wants to live in the requirements section. <span
 
@@ -997,11 +1046,11 @@
       </section>
       <section id="legacyCharacterEncoding">
         <h3>Legacy Character Encodings</h3>
-        <p>Finally, <a>resources</a> can use different
-          character encoding schemes, including <a>legacy
-            character encodings</a>, to serialize document formats on the Web.
-          Each character encoding scheme uses different byte values and
-          sequences to represent a given subset of the Universal Character Set.</p>
+        <p>Finally, <a>resources</a> can use different character encoding
+          schemes, including <a>legacy character encodings</a>, to serialize
+          document formats on the Web. Each character encoding scheme uses
+          different byte values and sequences to represent a given subset of the
+          Universal Character Set.</p>
         <div class="note">
           <p>Choosing a Unicode character encoding, such as UTF-8, for all
             documents, formats, and protocols is strongly encouraged, since no
@@ -1033,18 +1082,18 @@
           transcoder implementations faced choices about how to map specific
           byte sequences to Unicode. So the byte sequence <code>0x80.60</code>
           (<code>0x2141</code> in the JIS X 0208 character set) was mapped by
-          some implementations to <span class="uname" translate="no">U+301C WAVE DASH</span>
-          while others chose <span class="uname" translate="no">U+FF5E FULL WIDTH TILDE</span>.
-          This means that two reasonable, self-consistent, transcoders could
-          produce different Unicode character sequences from the same input. The
-          <cite>Encoding</cite> [[Encoding]] specification exists, in part, to
-          ensure that Web implementations use interoperable and identical
-          mappings. However, there is no guarantee that transcoders inconsistent
-          with the Encoding specification won't be applied to documents found on
-          the Web or used to process data appearing in a particular document
-          format or protocol.</p>
+          some implementations to <span class="uname" translate="no">U+301C
+            WAVE DASH</span> while others chose <span class="uname" translate="no">U+FF5E
+            FULL WIDTH TILDE</span>. This means that two reasonable,
+          self-consistent, transcoders could produce different Unicode character
+          sequences from the same input. The <cite>Encoding</cite> [[Encoding]]
+          specification exists, in part, to ensure that Web implementations use
+          interoperable and identical mappings. However, there is no guarantee
+          that transcoders inconsistent with the Encoding specification won't be
+          applied to documents found on the Web or used to process data
+          appearing in a particular document format or protocol.</p>
       </section>
-  </section>
+    </section>
     <section id="identityMatching">
       <h2>String Matching of Markup in Document Formats and Protocols</h2>
       <p>This chapter defines the implementation and requirements for string
@@ -1087,9 +1136,9 @@
               <li><em><a data-lt="ASCII case-insensitive">ASCII case folding</a></em>:
                 map all code points in the range 0x41 to 0x5A (A to Z) to the
                 corresponding code points in the range 0x61 to 0x7A (a to z).</li>
-              <li><em><a data-lt="case folding">Unicode case folding</a></em>: map
-                all code points to their Unicode C+F case fold equivalents. Note
-                that this can change the length of the string.</li>
+              <li><em><a data-lt="case folding">Unicode case folding</a></em>:
+                map all code points to their Unicode C+F case fold equivalents.
+                Note that this can change the length of the string.</li>
             </ol>
           </li>
           <li>Remove <a href="#unicodeControls">Unicode control characters</a></li>
@@ -1098,29 +1147,28 @@
         </ol>
         <br>
       </section>
-
-
-    <section id="convertingToCommonUnicodeForm">
-      <h2>Converting to a Common Unicode Form</h2>
-      <div class="requirement">
-        <p>[C][I] For content authors and implementations, it is RECOMMENDED
-          that conversions from legacy character encodings use a "normalizing
-          transcoder".</p>
-      </div>
-      <p id="def-normalizing-transcoder">A <span class="new-term">normalizing
-        transcoder</span> is a transcoder that converts from a <a href="#def-legacyEnc">legacy
-          character encoding</a> to a <a href="http://www.w3.org/TR/2005/REC-charmod-20050215/#Unicode_Encoding_Form">Unicode
+      <section id="convertingToCommonUnicodeForm">
+        <h2>Converting to a Common Unicode Form</h2>
+        <div class="requirement">
+          <p>[C][I] For content authors and implementations, it is RECOMMENDED
+            that conversions from legacy character encodings use a "normalizing
+            transcoder".</p>
+        </div>
+        <p id="def-normalizing-transcoder">A <span class="new-term">normalizing
+            transcoder</span> is a transcoder that converts from a <a href="#def-legacyEnc">legacy
+            character encoding</a> to a <a href="http://www.w3.org/TR/2005/REC-charmod-20050215/#Unicode_Encoding_Form">Unicode
             encoding form</a> <em>and</em> ensures that the result is in
-        Unicode Normalization Form C. For most legacy character encodings, it
-        is possible to construct a normalizing transcoder (by using any
-        transcoder followed by a normalizer); it is not possible to do so if
-        the encoding's <a href="http://www.w3.org/TR/2005/REC-charmod-20050215/#def-repertoire">repertoire</a> contains characters not represented in Unicode.</p>
-      <div class="requirement">
-        <p>[I] Authoring tools SHOULD provide a means of normalizing resources
-          and warn the user when a given resource is not in Unicode
-          Normalization Form C.</p>
-      </div>
-      <section>
+          Unicode Normalization Form C. For most legacy character encodings, it
+          is possible to construct a normalizing transcoder (by using any
+          transcoder followed by a normalizer); it is not possible to do so if
+          the encoding's <a href="http://www.w3.org/TR/2005/REC-charmod-20050215/#def-repertoire">repertoire</a>
+          contains characters not represented in Unicode.</p>
+        <div class="requirement">
+          <p>[I] Authoring tools SHOULD provide a means of normalizing resources
+            and warn the user when a given resource is not in Unicode
+            Normalization Form C.</p>
+        </div>
+        <section>
           <h4>Choice of Normalization Form</h4>
           <p>Given that there are many character sequences that content authors
             or applications could choose when inputting or exchanging text, and
@@ -1133,18 +1181,16 @@
             in <cite>Unicode in XML and other Markup Languages</cite>
             [[UNICODE-XML]] for a discussion). The NFKD and NFKC normalization
             forms are therefore excluded.</p>
-          <p>Among the remaining two forms, NFC has
-            the advantage that almost all legacy data (if transcoded trivially,
-            one-to-one, to a Unicode encoding), as well as data created by
-            current software, is already in this form; NFC also has a slight
-            compactness advantage and is a better match to user expectations
-            with respect to the character vs. <a>grapheme</a>
-            issue. This document therefore recommends, when possible, that all
-            content be stored and exchanged in Unicode Normalization Form C
-            (NFC).</p>
+          <p>Among the remaining two forms, NFC has the advantage that almost
+            all legacy data (if transcoded trivially, one-to-one, to a Unicode
+            encoding), as well as data created by current software, is already
+            in this form; NFC also has a slight compactness advantage and is a
+            better match to user expectations with respect to the character vs.
+            <a>grapheme</a> issue. This document therefore recommends, when
+            possible, that all content be stored and exchanged in Unicode
+            Normalization Form C (NFC).</p>
         </section>
-        
-      <section id="content-reqs">
+        <section id="content-reqs">
           <h4>Requirements for Resources</h4>
           <p>These requirements pertain to the authoring and creation of
             documents and are intended as guidelines for resource authors.</p>
@@ -1177,35 +1223,34 @@
               preceding base character in a resource.</p>
           </div>
           <p class="ednote">Following examples need improvement.</p>
-        <p>There can be exceptions to this, for example, when making a list of
+          <p>There can be exceptions to this, for example, when making a list of
             characters (such as a Unicode demo). This avoids problems with
             unintentional display or with naive implementations that combine the
             combining mark with adjacent markup or other natural language
-            content. For example, if you were to use <span class="uname" translate="no">U+301</span> as the
-            start of a "class" attribute value in HTML, the class name might not
-          display properly in your editor.</p>
+            content. For example, if you were to use <span class="uname" translate="no">U+301</span>
+            as the start of a "class" attribute value in HTML, the class name
+            might not display properly in your editor.</p>
         </section>
-          <div class="requirement">
-            <p>[S] Specifications of text-based formats and protocols MAY
-              specify that all or part of the textual content of that format or
-              protocol is normalized using Unicode Normalization Form C (NFC).</p>
-          </div>
-          <p>Specifications are generally discouraged from requiring formats or
-            protocols to store or exchange data in a normalized form unless
-            there are specific, clear reasons why the additional requirement is
-            necessary. As many document formats on the Web do not require
-            normalization, content authors might occasionally rely on
-            denormalized character sequences and a normalization step could
-            negatively affect such content.</p>
-          <div class="note">
-            <p>Requiring NFC requires additional care on the part of the
-              specification developer, as content on the Web generally is not in
-              a known normalization state. Boundary and error conditions for
-              denormalized content need to be carefully considered and well
-              specified in these cases. </p>
-          </div>
-          
-          <section id="non-normalizing">
+        <div class="requirement">
+          <p>[S] Specifications of text-based formats and protocols MAY specify
+            that all or part of the textual content of that format or protocol
+            is normalized using Unicode Normalization Form C (NFC).</p>
+        </div>
+        <p>Specifications are generally discouraged from requiring formats or
+          protocols to store or exchange data in a normalized form unless there
+          are specific, clear reasons why the additional requirement is
+          necessary. As many document formats on the Web do not require
+          normalization, content authors might occasionally rely on denormalized
+          character sequences and a normalization step could negatively affect
+          such content.</p>
+        <div class="note">
+          <p>Requiring NFC requires additional care on the part of the
+            specification developer, as content on the Web generally is not in a
+            known normalization state. Boundary and error conditions for
+            denormalized content need to be carefully considered and well
+            specified in these cases. </p>
+        </div>
+        <section id="non-normalizing">
           <h4> Non-Normalizing Specification Requirements </h4>
           <p class="ednote"> The following paragraph was changed and requires WG
             approval. </p>
@@ -1229,7 +1274,7 @@
               content being exchanged, read, parsed, or processed except when
               required to do so as a side-effect of transcoding the content to a
               Unicode character encoding, as content might depend on the
-            de-normalized representation. </p>
+              de-normalized representation. </p>
           </div>
           <p class="ednote"> The following requirement was noted by Mati as
             being problematic. It was not marked with mustard and needs further
@@ -1249,7 +1294,6 @@
               and SHOULD provide Extended or Tailored (Levels 2 and 3) support.</p>
           </div>
         </section>
-        
         <section id="normalizing-spec">
           <h4> Unicode Normalizing Specification Requirements </h4>
           <p>For specifications of text-based formats and protocols that define
@@ -1315,19 +1359,13 @@
               require that the final output of this mechanism be normalized. </p>
           </div>
         </section>
-    </section>
-
-
-
-
-    <section id="expandingCharacterEscapes">
-      <h2>Expanding Character Escapes and Includes</h2>
-      <p>Edit me!</p>
-    </section>
-
-
-    <section id="handlingCaseFolding">
-      <h2>Handling Case Folding</h2>
+      </section>
+      <section id="expandingCharacterEscapes">
+        <h2>Expanding Character Escapes and Includes</h2>
+        <p>Edit me!</p>
+      </section>
+      <section id="handlingCaseFolding">
+        <h2>Handling Case Folding</h2>
         <p>In the Web environment, where multiple character encodings are used
           to represent strings, including some character encodings which allow
           multiple representations for the same thing, it's important to
@@ -1342,12 +1380,12 @@
         <p>Where case-insensitive matching is desired, there are several
           implementation choices that a formal language needs to consider. If
           the vocabulary of strings to be compared is limited to the Basic Latin
-          (ASCII) subset of Unicode, ASCII case-insensitive
-          matching MAY be used.</p>
-        <p>If the vocabulary of strings to be compared is not limited, then <a>ASCII case-insensitive</a> matching MUST NOT be used. <a
-
-            href="#uci">Unicode case-insensitive</a> matching MUST be applied,
-          even if the vocabulary does not allow the full range of Unicode.</p>
+          (ASCII) subset of Unicode, ASCII case-insensitive matching MAY be
+          used.</p>
+        <p>If the vocabulary of strings to be compared is not limited, then <a>ASCII
+            case-insensitive</a> matching MUST NOT be used. <a href="#uci">Unicode
+            case-insensitive</a> matching MUST be applied, even if the
+          vocabulary does not allow the full range of Unicode.</p>
         <p><a href="#uci">Unicode case-insensitive</a> matching can take several
           forms. Unicode defines the "common" (C) casefoldings for characters
           that always have 1:1 mappings of the character to its case folded form
@@ -1394,22 +1432,22 @@
             user-defined values that use a broader range of Unicode, ASCII
             case-insensitive matching MUST NOT be required.</p>
         </div>
-         <div class="requirement">
-          <p>[S][I] The <a>Unicode C+F</a> case-fold form is
-            RECOMMENDED as the case-insensitive matching for <a data-lt="vocabulary">vocabularies</a>.
+        <div class="requirement">
+          <p>[S][I] The <a>Unicode C+F</a> case-fold form is RECOMMENDED as the
+            case-insensitive matching for <a data-lt="vocabulary">vocabularies</a>.
             The Unicode C+S form MUST NOT be used for string identity matching
             on the Web.</p>
         </div>
-         <p>Language-sensitive case-sensitive matching in document
-           formats and protocols is NOT RECOMMENDED because language information
-           can be hard to obtain, verify, or manage and the resulting operations
-           can produce results that frustrate users.</p>
-         <div class="requirement">
-           <p>[C] Identifiers SHOULD use consistent case (upper, lower, mixed
-             case) to facilitate matching, even if case-insensitive matching is
-             supported by the format or implementation. </p>
-         </div>
-<section id="formal-language">
+        <p>Language-sensitive case-sensitive matching in document formats and
+          protocols is NOT RECOMMENDED because language information can be hard
+          to obtain, verify, or manage and the resulting operations can produce
+          results that frustrate users.</p>
+        <div class="requirement">
+          <p>[C] Identifiers SHOULD use consistent case (upper, lower, mixed
+            case) to facilitate matching, even if case-insensitive matching is
+            supported by the format or implementation. </p>
+        </div>
+        <section id="formal-language">
           <h4>Requirements for Specifications</h4>
           <p>These requirements pertain to specifications for document formats
             or programming/scripting languages and their implementations.</p>
@@ -1454,30 +1492,24 @@
               ASCII-only case-insensitive matching for values or constructs that
               permit non-ASCII characters. </p>
           </div>
-      </section>
-        
+        </section>
         <section id="non-normalizing">
           <h4> Non-Normalizing Specification Requirements </h4>
           <div class="requirement">
             <p>[S][I] For vocabularies and values that are not restricted to
               Basic Latin (ASCII), case-insensitive matching MUST specify either
-            Unicode C+F or locale-sensitive string comparison. </p>
+              Unicode C+F or locale-sensitive string comparison. </p>
           </div>
         </section>
-        
       </section>
-
-
-    <section id="handlingUnicodeControls">
-      <h2>Handling Unicode Controls and Invisible Markers</h2>
-      <div class="requirement">
-        <p>Applications that do string matching SHOULD ignore Unicode
-          formatting controls such as variation selectors; grapheme or word
-          joiners; or other non-semantic controls.</p>
-      </div>
-
-        
-            </section>
+      <section id="handlingUnicodeControls">
+        <h2>Handling Unicode Controls and Invisible Markers</h2>
+        <div class="requirement">
+          <p>Applications that do string matching SHOULD ignore Unicode
+            formatting controls such as variation selectors; grapheme or word
+            joiners; or other non-semantic controls.</p>
+        </div>
+      </section>
     </section>
     <section id="searching">
       <h2>String Searching in Natural Language Content</h2>
@@ -1489,14 +1521,14 @@
         the Web <em>other than</em> that mandated by a formal language or
         document format.</p>
       <p>There are several different kinds of string searching.</p>
-      <p>When you are using a search engine, you are generally using a form of full text search. <dfn>Full text search</dfn> generally breaks
-        natural language text into word segments and may apply complex
-        processing to get at the semantic "root" values of words. For example,
-        if the user searches for "run", you might want to find words like
-        "running", "ran", or "runs" in addition to the actual search term "run".
-        This process, naturally, is sensitive to language, context, and many
-        other aspects of textual variation. It is also beyond the scope of this
-        document.</p>
+      <p>When you are using a search engine, you are generally using a form of
+        full text search. <dfn>Full text search</dfn> generally breaks natural
+        language text into word segments and may apply complex processing to get
+        at the semantic "root" values of words. For example, if the user
+        searches for "run", you might want to find words like "running", "ran",
+        or "runs" in addition to the actual search term "run". This process,
+        naturally, is sensitive to language, context, and many other aspects of
+        textual variation. It is also beyond the scope of this document.</p>
       <p>Another form of string searching, which we'll concern ourselves with
         here, is sub-string matching or "find" operations. This is the direct
         searching of the body or "corpus" of a document with the user's input.
@@ -1595,11 +1627,12 @@
           "user-perceived characters" can be important. See Section 3 of <cite>Character
             Model for the World Wide Web: Fundamentals</cite> [[!CHARMOD]] for a
           description. For example, if the user has entered a capital "A" into a
-          search box, should the software find the character À (<span class="uname" translate="no">U+00C0
-            LATIN CAPITAL LETTER A WITH ACCENT GRAVE</span>)? What about the
-          character "A" followed by U+0300 (a combining accent grave)? What
-          about writing systems, such as Devanagari, which use combining marks
-          to suppress or express certain vowels?</p>
+          search box, should the software find the character À (<span class="uname"
+
+            translate="no">U+00C0 LATIN CAPITAL LETTER A WITH ACCENT GRAVE</span>)?
+          What about the character "A" followed by U+0300 (a combining accent
+          grave)? What about writing systems, such as Devanagari, which use
+          combining marks to suppress or express certain vowels?</p>
       </section>
     </section>
     <section>
@@ -1618,16 +1651,27 @@
             and Notation</a></li>
         <li>Addition of section discussing <a href="#unicodeControls">Unicode
             controls</a>, including a new requirement.</li>
-        <li>Shakespeare -&gt; natural language content;    Wildebeest -&gt; resource;    namespace -&gt; vocabulary</li>
-        <li>Changed order of sections in section on &quot;The String Matching Problem&quot;</li>
-        <li>Edited intro and integrated the case folding text from the string matching algorithm into the case folding section.</li>
-        <li>Replaced the table in Section 2.2.1 as a first attempt to fix the various examples we borrowed from UAX15.</li>
-        <li>Replaced first table in normalization section with a list of examples, addressing existing ednote.</li>
-        <li> Extensive changes to incorporate the &quot;standard&quot; styles for  International docs.</li>
-        <li>Added explanatory text to the compatibility equivalents examples. Added characters to the table to further illustrate each category. Removed the &quot;note&quot; marker around additional explanatory text and edited. Removed the ednote saying this was needed.</li>
-        <li>Changes to SOTD and top matter to reflect new i18n publication process.</li>
+        <li>Shakespeare -&gt; natural language content; Wildebeest -&gt;
+          resource; namespace -&gt; vocabulary</li>
+        <li>Changed order of sections in section on "The String Matching
+          Problem"</li>
+        <li>Edited intro and integrated the case folding text from the string
+          matching algorithm into the case folding section.</li>
+        <li>Replaced the table in Section 2.2.1 as a first attempt to fix the
+          various examples we borrowed from UAX15.</li>
+        <li>Replaced first table in normalization section with a list of
+          examples, addressing existing ednote.</li>
+        <li> Extensive changes to incorporate the "standard" styles for
+          International docs.</li>
+        <li>Added explanatory text to the compatibility equivalents examples.
+          Added characters to the table to further illustrate each category.
+          Removed the "note" marker around additional explanatory text and
+          edited. Removed the ednote saying this was needed.</li>
+        <li>Changes to SOTD and top matter to reflect new i18n publication
+          process.</li>
       </ul>
-      <p>See the <a href="https://github.com/w3c/charmod-norm/commits/gh-pages">github commit log</a> for more details.</p>
+      <p>See the <a href="https://github.com/w3c/charmod-norm/commits/gh-pages">github
+          commit log</a> for more details.</p>
     </section>
     <section>
       <h2 id="Acknowledgements" class="informative">Acknowledgements</h2>
@@ -1645,5 +1689,6 @@
           Progress Software)</li>
       </ul>
     </section>
+    
   </body>
 </html>

--- a/local.css
+++ b/local.css
@@ -108,8 +108,8 @@ span.tableSub {
     
 span.dropExample {
     float: left;
-    width: 3em;
-    margin-left: -3em;
+    width: 6em;
+    margin-left: -6em;
     text-align: center;
     font-size: 200%;
     font-family: sans-serif;
@@ -121,7 +121,7 @@ ul.dropExampleList {
 }
     
 li.dropExampleItem {
-   padding-left: 4em;
+   padding-left: 6em;
    margin-bottom: 1em;
 }
     


### PR DESCRIPTION
…ation section no longer wraps

Addressing the following issues:

https://github.com/w3c/charmod-norm/issues/11

o Removed the exemplery title "Much Ado About Nothing"

https://github.com/w3c/charmod-norm/issues/10

o Rewrote the definition of grapheme, made clear that
  we mean extended default grapheme clusters unless otherwise
  noted, and added a Hindi example.
