### PR TITLE
Turn off hyphenation in terminology example.

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,7 +406,7 @@
         <section>
         <h5>Terminology Examples</h5>
         <p>This section illustrates some of the terminology defined above. For illustration purposes we'll use the following small HTML file as an example (line numbers added for reference):</p>
-          <div style="background-color:white;text-align: left; border-style: solid; border-width:3px; padding-left: 50px; padding-right: 50px; padding-top: 10px; padding-bottom: 10px; width: 80%">
+          <div class=terminologyExample>
             <p class=syntaxExample><span class=lnum>1 </span> <span class="markup">&lt;<span class="vocabulary">html</span> <span class="vocabulary">lang</span>="<span class=userValue>en</span>" <span class="vocabulary">dir</span>="<span class="vocabulary">ltr</span>"&gt;</p>
             <p class=syntaxExample><span class=lnum>2 </span>&lt;<span class="vocabulary">head</span>&gt;</span></p>
             <p class=syntaxExample><span class=lnum>3 </span><span class="markup">&nbsp;&nbsp;&lt;<span class="vocabulary">meta</span> <span class="vocabulary">charset</span>="<span class=userValue>UTF-8</span>"&gt;</p>

--- a/local.css
+++ b/local.css
@@ -229,7 +229,21 @@ p.quote {
      font-size: 140%;
 }
 
+div.terminologyExample {
+     background-color:white;
+     text-align: left; 
+     border-style: solid; 
+     border-width:3px; 
+     padding-left: 20px; 
+     padding-right: 20px; 
+     padding-top: 10px; 
+     padding-bottom: 10px; 
+     width: 90%;
+}
+
 .lnum {
+    float: left;
+    margin-left: -15px;
     font-size: 75%;
     color: gray;
     font-family: Lucida Console,NoToFu,monospace;
@@ -239,6 +253,7 @@ p.syntaxExample {
     padding: 0px;
     margin-top: 0px;
     margin-bottom: 0px;
+    hyphens: none;
 }
 
 


### PR DESCRIPTION
Move styles for terminology example div to local.css.
Adjust line numbers so wrapped lines are separate.