### PR TITLE
Fix #202 Errata reported by @shujikamitsuna

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <script class="remove">
       var respecConfig = {
           // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
-          specStatus:				"WG-NOTE",
+          specStatus:				"WD",
           publishDate:  			"2019-01-30",
           previousPublishDate:  	"2018-04-20",
           previousMaturity:  		"WD",

--- a/index.html
+++ b/index.html
@@ -1395,6 +1395,22 @@
         
       <p>This chapter defines the requirements for specifying and implementing string matching in <a href="#def_syntactic_content" class="termref">syntactic content</a>.</p>
       
+      <section id="specifying-content-restrictions">
+		  <h2>Specifying Content Restrictions</h2>
+		  
+		  <p>One of the ways in which string matching can be made more effective and consistent is by applying restrictions to the content that is to be matched. Document formats and protocols often do this by defining a namespace or set of rules for what is legal in a given context.</p>
+		  
+		  <p>There are two broad classes that strings or identifier types fall into: those that are meant to be seen, read, or interacted with by humans (and thus might be expected to contain natural language text); and those that are application or protocol internal and not intended for human interaction.</p>
+		  
+		  <p class="requirement"><span class="qrec">[S]</span> When identifiers are supposed to be meaningful to actual users, specifications SHOULD allow the full range of Unicode, in order to ensure that user in all languages can use the resulting document format or protocol with equal access.</p>
+		  
+		  <p>Often these identifiers can be assigned or edited by the end user or presented to the user for selection. Examples of user-facing identifiers include SSIDs, device names, or user-defined settings. Identifiers of this sort are more complex to match due to the issues described in this document, but provide the best experience for human interaction.</p>
+		  
+		  <p class="requirement"><span class="qrec">[S]</span> When identifiers are never shown to users and are always used for matching or processing within an application or protocol, specifications SHOULD limit the content to a printable subset of ASCII. ASCII case-insensitivity is RECOMMENDED.</p>
+		  
+		  <p>These sorts of "application internal" identifiers are often human-readable and contain words (generally in English). This is an affordance for developers who have to work with or debug the contents of a document format or protocol. However, any such fields or values should always be wrapped with a localizable display name when shown to users and not expected to form any part of an end-user interaction.</p>
+      </section>
+      
       <section id="choosingMatchingAlgorithm">
         <h2>Choosing a Matching Algorithm</h2>
         

--- a/index.html
+++ b/index.html
@@ -1412,15 +1412,17 @@
 		  
 		  <p>There are two broad classes of identifier: <a>user-facing identifiers</a> and <a>application internal identifiers</a>.</p>
 		  
-		  <p><a>Application internal identifiers</a> are the part of a document format or protocol's <a>vocabulary</a> that are machine readable and not intended for display. These are often given meaningful names (generally in English) as an affordance for developers or content authors who have to work with or debug the contents of a document format or protocol. Any such fields or values should always be wrapped with a localizable display name when shown to users and not expected to form any part of an end-user interaction.</p>
+		  <p><a>Application internal identifiers</a> are the part of a document format or protocol's <a>vocabulary</a> that are machine readable and not intended for display. These are often given meaningful names (generally in English) as an affordance for developers or content authors who have to work with or debug the contents of a document format or protocol.</p>
 		  
-		  <p class="requirement"><span class="qrec">[S]</span> Specifications that define <a>application internal identifiers</a> (which are never shown to users and are always used for matching or processing within an application or protocol) SHOULD limit the content to a printable subset of ASCII. ASCII case-insensitivity is RECOMMENDED.</p>
+		  <p class="requirement"><span class="qrec">[S]</span> Specifications that define <a>application internal identifiers</a> (which are never shown to users and are always used for matching or processing within an application or protocol) SHOULD limit the content to a printable subset of ASCII. ASCII case folding is RECOMMENDED.</p>
+		  
+		  <p class="requirement"<span class="qrec">[S][I]</span> <a>Application internal identifier</a> fields or values MUST be wrapped with a localizable display value when displayed to end-users.</p>
 		  
 		  <p><a>User-facing identifiers</a> are the part of a document format or protocol's <a>vocabulary</a> that are assigned or edited by users or presented to the user for selection. Examples of user-facing identifiers include network names (such as SSIDs); device names; class, style, or attribute names; or user-defined settings or values. Identifiers of this sort are more complex to match due to the issues described in this document, but provide the best experience, particularly for users who do not speak English or who are less familiar with the Latin script.</p>
 		  
 		  <p>Many <a>user-facing identifiers</a> are also <a>user-supplied values</a> and can be assigned by users of the document format or protocol. The ability to use the natural language preferred by the user or the user's community or culture provides a superior user experience and makes features more accessible to audiences that may have limited language skills, particularly in English.</p>		  
 		  
-		  <p class="requirement"><span class="qrec">[S]</span> When identifiers are visible or potentially visible to users, specifications SHOULD allow the use of non-ASCII Unicode characters, in order to ensure that users in all languages can use the resulting document format or protocol with equal access.</p>
+		  <p class="requirement"><span class="qrec">[S]</span> When identifiers are visible or potentially visible to users, specifications SHOULD allow the use of non-ASCII Unicode characters, in order to ensure that users in all languages can use the resulting document format or protocol with equal access. Case sensitivity (i.e. no case folding) is RECOMMENDED.</p>
 		  
 		  <p>While a wide range of Unicode characters ought to be permitted, specifications can still impose certain practical limits on the content of <a>user-facing identifiers</a>. One example of a specification that defines content rules of this type can be found in <cite>Unicode Identifier and Pattern Syntax</cite> [[UAX31]].</p>
 

--- a/index.html
+++ b/index.html
@@ -1404,17 +1404,19 @@
       <section id="specifying-content-restrictions">
 		  <h2>Specifying Content Restrictions</h2>
 		  
-		  <p>One of the ways in which string matching can be made more effective and consistent is by applying restrictions to the content that is to be matched. When building a <a>vocabulary</a> and especially when defining <a>user-supplied values</a> within that vocabulary, specifications for document formats and protocols often define a namespace or set of rules for what is legal in a given context. This usually includes length and content restrictions.</p>
+		  <p>One of the ways in which string matching can be made more effective and consistent is by applying restrictions to the content that is to be matched. The definition of a <a>vocabulary</a>, especially one that permits <a>user-supplied values</a> within that vocabulary, necessarily includes the rules for what makes a "valid identifier". This usually includes length and content restrictions. Some best practices for defining these restrictions include the following:</p>
 		  
-		  <p class="requirement"><span class="qrec">[S]</span> Specifications SHOULD NOT allow the <code>C0</code> (<span class=uname>U+0000</span> to <span class=uname>U+001F</span>) and <code>C1</code> (<span class=uname>U+0080</span> to <span class=uname>U+009F</span>) control characters.</p>
+		  <p class="requirement"><span class="qrec">[S]</span> Specifications SHOULD NOT allow surrogate code points (<span class=uname>U+D800</span> to <span class=uname>U+DFFF</span>) or non-character code points in identifiers.</p>
 		  
-		  <p>There are two broad classes of identifer: <a>user-facing identifiers</a> and <a>application internal identifiers</a>.</p>
+		  <p class="requirement"><span class="qrec">[S]</span> Specifications SHOULD NOT allow the <code>C0</code> (<span class=uname>U+0000</span> to <span class=uname>U+001F</span>) and <code>C1</code> (<span class=uname>U+0080</span> to <span class=uname>U+009F</span>) control characters in identifiers.</p>
+		  
+		  <p>There are two broad classes of identifier: <a>user-facing identifiers</a> and <a>application internal identifiers</a>.</p>
 		  
 		  <p><a>Application internal identifiers</a> are the part of a document format or protocol's <a>vocabulary</a> that are machine readable and not intended for display. These are often given meaningful names (generally in English) as an affordance for developers or content authors who have to work with or debug the contents of a document format or protocol. Any such fields or values should always be wrapped with a localizable display name when shown to users and not expected to form any part of an end-user interaction.</p>
 		  
 		  <p class="requirement"><span class="qrec">[S]</span> Specifications that define <a>application internal identifiers</a> (which are never shown to users and are always used for matching or processing within an application or protocol) SHOULD limit the content to a printable subset of ASCII. ASCII case-insensitivity is RECOMMENDED.</p>
 		  
-		  <p><a>User-facing identifiers</a> are the part of a document format or protocol's <a>vocabulary</a> that are assigned or edited by users or presented to the user for selection. Examples of user-facing identifiers include network names (such as SSIDs); device names; class or style names; or user-defined settings. Identifiers of this sort are more complex to match due to the issues described in this document, but provide the best experience, particularly for users who do not speak English or who are less familiar with the Latin script.</p>
+		  <p><a>User-facing identifiers</a> are the part of a document format or protocol's <a>vocabulary</a> that are assigned or edited by users or presented to the user for selection. Examples of user-facing identifiers include network names (such as SSIDs); device names; class, style, or attribute names; or user-defined settings or values. Identifiers of this sort are more complex to match due to the issues described in this document, but provide the best experience, particularly for users who do not speak English or who are less familiar with the Latin script.</p>
 		  
 		  <p>Many <a>user-facing identifiers</a> are also <a>user-supplied values</a> and can be assigned by users of the document format or protocol. The ability to use the natural language preferred by the user or the user's community or culture provides a superior user experience and makes features more accessible to audiences that may have limited language skills, particularly in English.</p>		  
 		  

--- a/index.html
+++ b/index.html
@@ -1764,7 +1764,7 @@ HE&#x141;&#x141;O
    
     <section class=appendix>
       <h2 id="changeLog" class="informative">Changes Since the Last Published Version</h2>
-      <p>Changes to this document since the <a href="http://www.w3.org/TR/2014/WD-charmod-norm-20180420/Overview.html">Working Draft</a> of 2018-04-20 are available via the <a href="https://github.com/w3c/charmod-norm/commits/gh-pages">github commit log</a>.</p>
+      <p>Changes to this document (beginning with the <a href="http://www.w3.org/TR/2014/WD-charmod-norm-20180420/Overview.html">Working Draft</a> of 2018-04-20) are available via the <a href="https://github.com/w3c/charmod-norm/commits/gh-pages">github commit log</a>.</p>
     </section>
     <section class=appendix>
       <h2 id="Acknowledgements" class="informative">Acknowledgements</h2>

--- a/index.html
+++ b/index.html
@@ -1420,7 +1420,7 @@
 		  
 		  <p>Many <a>user-facing identifiers</a> are also <a>user-supplied values</a> and can be assigned by users of the document format or protocol. The ability to use the natural language preferred by the user or the user's community or culture provides a superior user experience and makes features more accessible to audiences that may have limited language skills, particularly in English.</p>		  
 		  
-		  <p class="requirement"><span class="qrec">[S]</span> When identifiers are supposed to be meaningful to actual users, specifications SHOULD NOT prohibit the use of non-ASCII Unicode characters, in order to ensure that user in all languages can use the resulting document format or protocol with equal access.</p>
+		  <p class="requirement"><span class="qrec">[S]</span> When identifiers are visible or potentially visible to users, specifications SHOULD allow the use of non-ASCII Unicode characters, in order to ensure that users in all languages can use the resulting document format or protocol with equal access.</p>
 		  
 		  <p>While a wide range of Unicode characters ought to be permitted, specifications can still impose certain practical limits on the content of <a>user-facing identifiers</a>. One example of a specification that defines content rules of this type can be found in <cite>Unicode Identifier and Pattern Syntax</cite> [[UAX31]].</p>
 

--- a/index.html
+++ b/index.html
@@ -195,7 +195,7 @@
         
         <p>The goal of the Character Model for the World Wide Web is to facilitate use of the Web by all people, regardless of their language, script, writing system, or cultural conventions, in accordance with the <a href="http://www.w3.org/Consortium/mission"><cite>W3C goal of universal access</cite></a>. One basic prerequisite to achieve this goal is to be able to transmit and process the characters used around the world in a well-defined and well-understood way.</p>
         
-        <p class="note">This document builds on <cite>Character Model for the World Wide Web: Fundamentals</cite> [[!CHARMOD]]. Understanding the concepts in that document are important to being able to understand nd apply this document successfully.</p>
+        <p class="note">This document builds on <cite>Character Model for the World Wide Web: Fundamentals</cite> [[!CHARMOD]]. Understanding the concepts in that document are important to being able to understand and apply this document successfully.</p>
         
         <p>This part of the Character Model for the World Wide Web covers string 
 		matching—the process by which a specification or implementation defines 
@@ -669,7 +669,7 @@
         <p>A different kind of variation can occur in Unicode text: sometimes several different <a>Unicode code point</a> sequences can be used to represent the same abstract character. When searching or matching text by comparing code points, these variations in encoding cause text values not to match that users expect to be the same. </p>
 
       <aside class=example id=aringExample title="Encoding Variations">
-		  <p>Consider the character <span class="codepoint"><span lang="en">&#x01FA;</span> [<span class="uname">U+01FA LATIN CAPITAL LETTER A WITH RING ABOVE AND ACUTE</span>]</span>. One way to encode this character is as <span class="uname" translate="no"> U+01FA LATIN LETTER CAPITAL A WITH RING ABOVE AND ACUTE</span>. Here are some of the different character sequences that a document could use to represent this character:</p>
+		  <p>Consider the character <span class="codepoint"><span lang="en">&#x01FA;</span> [<span class="uname">U+01FA LATIN CAPITAL LETTER A WITH RING ABOVE AND ACUTE</span>]</span>. One way to encode this character is as <span class="uname" translate="no"> U+01FA LATIN CAPITAL LETTER A WITH RING ABOVE AND ACUTE</span>. Here are some of the different character sequences that a document could use to represent this character:</p>
           <table>
 			  <tr>
                  <td class=exampleChar style="width:10%">&#x01FA;</td>
@@ -890,7 +890,7 @@
                     <td rowspan=4><strong>Others</strong>—compatibility characters encoded for other reasons, generally for compatibility with legacy character encodings. Many of these characters are simply a sequence of characters encoded as a single presentational unit.</td>
                     <td style="text-align: center"> <span class="exampleChar">&#x1c6;</span><br><span class=uname>U+01C6</span></td>
                     <td style="text-align: center">&#x21d2;</td>
-                    <td style="text-align: center"><span class="exampleChar">d&#x17e;</span><br><span class=uname>U+017E</span></td>
+                    <td style="text-align: center"><span class="exampleChar">d&#x17e;</span><br><span class=uname>U+0064 U+017E</span></td>
                   </tr><tr>
                     <td style="text-align: center"> <span class="exampleChar">&#x2474;</span><br><span class=uname>U+2474</span></td>
                     <td style="text-align: center">&#x21d2;</td>
@@ -1263,7 +1263,7 @@
 		  <p>The character <span class="uname" translate="no">U+034F Combining Grapheme Joiner</span>, 
 		  whose name is misleading (as it does not join graphemes), is used to separate characters that might otherwise be 
 		  considered a grapheme for the purposes of sorting or to provide a 
-		  means of maintaing certain textual distinctions when applying Unicode 
+		  means of maintaining certain textual distinctions when applying Unicode 
 		  normalization to text. </p>
 		  <p>Whitespace variations can also affect the interpretation and 
 		  matching of text. For example, the various non-breaking space 
@@ -1315,8 +1315,8 @@
 	     
 	  <p>An emoji character can also be followed by a <a href="#variationSelectors">variation
 	     selector</a> to indicate text (black and white, indicated by 
-	     <span class="uname">U+FF0E Variation Selector 15</span>) or color 
-	     (indicated by <span class="uname">U+FF0F Variation Selector 16</span>) presentation
+	     <span class="uname">U+FE0E Variation Selector 15</span>) or color 
+	     (indicated by <span class="uname">U+FE0F Variation Selector 16</span>) presentation
 	     of the base emoji.</p>
 	  
 	  <p>Still another wrinkle in the use of emoji are flags. National flags can be composed using country codes derived from the [[BCP47]] registry, such as the sequence <span class="codepoint"><span lang="en">&#x1F1FF;</span> [<span class="uname">U+1F1FF REGIONAL INDICATOR SYMBOL LETTER Z</span>]</span> <span class="codepoint"><span lang="en">&#x1F1F2;</span> [<span class="uname">U+1F1F2 REGIONAL INDICATOR SYMBOL LETTER M</span>]</span>, which is the country code (<kbd>ZM</kbd>) for the country Zambia: &#x1f1ff;&#x1f1f2;. Other regional or special purpose flags can be composed using a flag emoji with various symbols or with regional indicator codes terminating in a cancel tag. For example, the flag of Scotland (🏴󠁧󠁢󠁳󠁣󠁴󠁿) can be composed like this: </p>
@@ -1343,7 +1343,7 @@
         <div class="note">
           <p><strong>Choosing a Unicode character encoding, such as UTF-8, for all documents, formats, and protocols is a strongly encouraged <a href="#convertingToCommonUnicodeForm">recommendation</a></strong>, since there is no additional utility to be gained from using a legacy character encoding and the considerations in the rest of this section would be completely avoided.</p>
         </div>
-        <p>For example, <span class="codepoint"><span lang="en">&#x20AC;</span> [<span class="uname">U+20AC EURO SIGN</span>]</span>) is encoded as the byte sequence <code>0xE2.82.AC</code>
+        <p>For example, <span class="codepoint"><span lang="en">&#x20AC;</span> [<span class="uname">U+20AC EURO SIGN</span>]</span> is encoded as the byte sequence <code>0xE2.82.AC</code>
           in the <code class="kw">UTF-8</code> character encoding. This same
           character is encoded as the byte sequence <code>0x80</code> in the
           legacy character encoding <code class="kw">windows-1252</code>.
@@ -1534,7 +1534,7 @@ HE&#x141;&#x141;O
         <p>Most transcoders used on the Web produce NFC as their output, but several do not. This is usually to allow the transcoder to be round-trip compatible with the source legacy character encoding, to preserve other character distinctions, or to be consistent with other transcoders in use in user-agents. This means that the Encoding specification [[!Encoding]] and various other important transcoding implementations include a number of non-normalizing transcoders. Indeed, most compatibility characters in Unicode exist solely for round-trip conversion from legacy encodings and a number of these have singleton canonical mappings in NFC. You saw an example of this <a href="#unicodeNormalization">earlier in the document</a> with <span class="codepoint"><span lang="en">&#x212B;</span> [<span class="uname">U+212B ANGSTROM SIGN</span>]</span>.</p> 
         
                 
-        <p>Bear in mind that most transcoders produce NFC output and that even those transcoders that do not produce NFC for all characters produce NFC for the preponderence of characters. In particular, there are no commonly-used transcoders that produce decomposed forms where precomposed forms exist or which produce a different combining character sequence from the normalized sequence (and this is true for <em>all</em> of the transcoders in [[!Encoding]]).</p>
+        <p>Bear in mind that most transcoders produce NFC output and that even those transcoders that do not produce NFC for all characters produce NFC for the preponderance of characters. In particular, there are no commonly-used transcoders that produce decomposed forms where precomposed forms exist or which produce a different combining character sequence from the normalized sequence (and this is true for <em>all</em> of the transcoders in [[!Encoding]]).</p>
                
         <div class=practice>
 			<p class=requirement><span id="practice-allowUnicode" class=practiceLab><span class=qrec>[S]</span> Specifications MUST allow a Unicode character encoding.</span></p>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <script class="remove">
       var respecConfig = {
           // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
-          specStatus:				"WD",
+          specStatus:				"ED",
           publishDate:  			"2019-01-30",
           previousPublishDate:  	"2018-04-20",
           previousMaturity:  		"WD",

--- a/index.html
+++ b/index.html
@@ -335,6 +335,12 @@
 		or variable name. It applies different rules for other cases, such as to 
 		the values of string literals.</p>
 		
+		<p>Values within a <a>vocabulary</a> fall into two broad classes: those that are meant to be seen, read, or interacted with by humans (and thus might be expected to contain natural language text); and those that are application or protocol internal and not intended for human interaction.</p>
+		
+		<p>A <dfn>user-facing identifier</dfn> is an identifier defined by or assigned by a user in a <a>vocabulary</a> that is intended to be at least potentially visible to end-users.</p>
+		
+		<p>An <dfn>application internal identifier</dfn> is an identifier defined by or assigned by a user in a <a>vocabulary</a> that is internal to the document format or protocol and not intended for human interaction.</p>
+		
         <p>A <dfn data-lt="grapheme|graphemes">grapheme</dfn> is a sequence of
           one or more characters in a visual representation of some text
           that a typical user would perceive as being a single unit (<q>character</q>).
@@ -1398,17 +1404,24 @@
       <section id="specifying-content-restrictions">
 		  <h2>Specifying Content Restrictions</h2>
 		  
-		  <p>One of the ways in which string matching can be made more effective and consistent is by applying restrictions to the content that is to be matched. Document formats and protocols often do this by defining a namespace or set of rules for what is legal in a given context.</p>
+		  <p>One of the ways in which string matching can be made more effective and consistent is by applying restrictions to the content that is to be matched. When building a <a>vocabulary</a> and especially when defining <a>user-supplied values</a> within that vocabulary, specifications for document formats and protocols often define a namespace or set of rules for what is legal in a given context. This usually includes length and content restrictions.</p>
 		  
-		  <p>There are two broad classes that strings or identifier types fall into: those that are meant to be seen, read, or interacted with by humans (and thus might be expected to contain natural language text); and those that are application or protocol internal and not intended for human interaction.</p>
+		  <p class="requirement"><span class="qrec">[S]</span> Specifications SHOULD NOT allow the <code>C0</code> (<span class=uname>U+0000</span> to <span class=uname>U+001F</span>) and <code>C1</code> (<span class=uname>U+0080</span> to <span class=uname>U+009F</span>) control characters.</p>
 		  
-		  <p class="requirement"><span class="qrec">[S]</span> When identifiers are supposed to be meaningful to actual users, specifications SHOULD allow the full range of Unicode, in order to ensure that user in all languages can use the resulting document format or protocol with equal access.</p>
+		  <p>There are two broad classes of identifer: <a>user-facing identifiers</a> and <a>application internal identifiers</a>.</p>
 		  
-		  <p>Often these identifiers can be assigned or edited by the end user or presented to the user for selection. Examples of user-facing identifiers include SSIDs, device names, or user-defined settings. Identifiers of this sort are more complex to match due to the issues described in this document, but provide the best experience for human interaction.</p>
+		  <p><a>Application internal identifiers</a> are the part of a document format or protocol's <a>vocabulary</a> that are machine readable and not intended for display. These are often given meaningful names (generally in English) as an affordance for developers or content authors who have to work with or debug the contents of a document format or protocol. Any such fields or values should always be wrapped with a localizable display name when shown to users and not expected to form any part of an end-user interaction.</p>
 		  
-		  <p class="requirement"><span class="qrec">[S]</span> When identifiers are never shown to users and are always used for matching or processing within an application or protocol, specifications SHOULD limit the content to a printable subset of ASCII. ASCII case-insensitivity is RECOMMENDED.</p>
+		  <p class="requirement"><span class="qrec">[S]</span> Specifications that define <a>application internal identifiers</a> (which are never shown to users and are always used for matching or processing within an application or protocol) SHOULD limit the content to a printable subset of ASCII. ASCII case-insensitivity is RECOMMENDED.</p>
 		  
-		  <p>These sorts of "application internal" identifiers are often human-readable and contain words (generally in English). This is an affordance for developers who have to work with or debug the contents of a document format or protocol. However, any such fields or values should always be wrapped with a localizable display name when shown to users and not expected to form any part of an end-user interaction.</p>
+		  <p><a>User-facing identifiers</a> are the part of a document format or protocol's <a>vocabulary</a> that are assigned or edited by users or presented to the user for selection. Examples of user-facing identifiers include network names (such as SSIDs); device names; class or style names; or user-defined settings. Identifiers of this sort are more complex to match due to the issues described in this document, but provide the best experience, particularly for users who do not speak English or who are less familiar with the Latin script.</p>
+		  
+		  <p>Many <a>user-facing identifiers</a> are also <a>user-supplied values</a> and can be assigned by users of the document format or protocol. The ability to use the natural language preferred by the user or the user's community or culture provides a superior user experience and makes features more accessible to audiences that may have limited language skills, particularly in English.</p>		  
+		  
+		  <p class="requirement"><span class="qrec">[S]</span> When identifiers are supposed to be meaningful to actual users, specifications SHOULD NOT prohibit the use of non-ASCII Unicode characters, in order to ensure that user in all languages can use the resulting document format or protocol with equal access.</p>
+		  
+		  <p>While a wide range of Unicode characters ought to be permitted, specifications can still impose certain practical limits on the content of <a>user-facing identifiers</a>. One example of a specification that defines content rules of this type can be found in <cite>Unicode Identifier and Pattern Syntax</cite> [[UAX31]].</p>
+
       </section>
       
       <section id="choosingMatchingAlgorithm">


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 403 Forbidden :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Sep 17, 2020, 4:13 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fcharmod-norm%2Fpull%2F203%2F91418dc.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Faphillips%2Fcharmod-norm%2Fpull%2F203.html)

```

<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US">
<head><title>HTML Diff service</title>
<link rel="stylesheet" href="http://www.w3.org/StyleSheets/base" />
</head>
<body>

<p><a href="http://www.w3.org/"><img src="http://www.w3.org/Icons/w3c_home" alt="W3C"/></a> <a href="http://www.w3.org/2003/Editors">W3C Editors homepage</a></p>

<h1>Create Diff between HTML pages</h1>

<p style='color:#FF0000'>An error (403 Forbidden) occured trying to get <a href='https://pr-preview.s3.amazonaws.com/w3c/charmod-norm/pull/203/91418dc.html'>https://pr-preview.s3.amazonaws.com/w3c/charmod-norm/pull/203/91418dc.html</a>.</p>

<form method="GET">
<p>Address of reference document: <input name="doc1" type="url" value="https://pr-preview.s3.amazonaws.com/w3c/charmod-norm/pull/203/91418dc.html" style="width:100%"/></p>
<p>Address of new document: <input name="doc2" value="https://pr-preview.s3.amazonaws.com/aphillips/charmod-norm/pull/203.html"  style="width:100%"/></p>
<p><input type="submit" value="get Diff"/></p>
</form>

<p><strong>Tip</strong>: if the document uses the W3C convention on linking to its previous version, you can specify only the address of the new document — the previous link will be automatically detected.</p>
<h2>Diff markings</h2>
<p>This service relies on <a href="https://www.gnu.org/software/diffutils/">GNU diff</a>. The found differences are roughly marked as follow:
<ul>
<li>deleted text is shown in pink with down-arrows (as styled for a &lt;del> element)</li>
<li>where there is replacement, it’s shown in green with bi-directional arrows,</li>
<li>where there is newly inserted text, it’s yellow with up arrows (&lt;ins> element)</li>
</ul>
<address>
script $Revision$ of $Date$<br />
by <a href="http://www.w3.org/People/Dom/">Dominique Hazaël-Massieux</a><br />based on <a href="https://github.com/w3c/htmldiff-ui/blob/master/htmldiff.pl">Shane McCarron’ Perl script</a> wrapped in a <a href="https://github.com/w3c/htmldiff-ui/blob/master/htmldiff">Python CGI</a>
</address>
</body>
</html>


```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/charmod-norm%23203.)._
</details>
