### PR TITLE
Fix respec warning and one typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
 </script> </head>
   <body>
     <section id="abstract">
-      <p>This document builds upon on <cite>Character Model for the World Wide Web 1.0: Fundamentals </cite>[[!CHARMOD]] to provide authors of specifications, software developers, and content developers a common reference on string identity matching on the World Wide Web and thereby increase interoperability.</p>
+      <p>This document builds upon on <cite>Character Model for the World Wide Web 1.0: Fundamentals </cite>[[CHARMOD]] to provide authors of specifications, software developers, and content developers a common reference on string identity matching on the World Wide Web and thereby increase interoperability.</p>
     </section>
     <section id="sotd">
       <div class="note">

--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@
   <body>
     <section id="abstract">
       <p>This document builds upon on <cite>Character Model for the World Wide
-          Web 1.0: Fundamentals </cite>[[!CHARMOD]] to provide authors of
+          Web 1.0: Fundamentals </cite>[[CHARMOD]] to provide authors of
         specifications, software developers, and content developers a common
         reference on string identity matching on the World Wide Web and thereby
         increase interoperability. </p>
@@ -1416,7 +1416,7 @@
 		  
 		  <p class="requirement"><span class="qrec">[S]</span> Specifications that define <a>application internal identifiers</a> (which are never shown to users and are always used for matching or processing within an application or protocol) SHOULD limit the content to a printable subset of ASCII. ASCII case folding is RECOMMENDED.</p>
 		  
-		  <p class="requirement"<span class="qrec">[S][I]</span> <a>Application internal identifier</a> fields or values MUST be wrapped with a localizable display value when displayed to end-users.</p>
+		  <p class="requirement"><span class="qrec">[S][I]</span> <a>Application internal identifier</a> fields or values MUST be wrapped with a localizable display value when displayed to end-users.</p>
 		  
 		  <p><a>User-facing identifiers</a> are the part of a document format or protocol's <a>vocabulary</a> that are assigned or edited by users or presented to the user for selection. Examples of user-facing identifiers include network names (such as SSIDs); device names; class, style, or attribute names; or user-defined settings or values. Identifiers of this sort are more complex to match due to the issues described in this document, but provide the best experience, particularly for users who do not speak English or who are less familiar with the Latin script.</p>
 		  

--- a/index.html
+++ b/index.html
@@ -136,11 +136,7 @@
 </script> </head>
   <body>
     <section id="abstract">
-      <p>This document builds upon on <cite>Character Model for the World Wide
-          Web 1.0: Fundamentals </cite>[[CHARMOD]] to provide authors of
-        specifications, software developers, and content developers a common
-        reference on string identity matching on the World Wide Web and thereby
-        increase interoperability.</p>
+      <p>This document builds upon on <cite>Character Model for the World Wide Web 1.0: Fundamentals </cite>[[!CHARMOD]] to provide authors of specifications, software developers, and content developers a common reference on string identity matching on the World Wide Web and thereby increase interoperability.</p>
     </section>
     <section id="sotd">
       <div class="note">
@@ -176,7 +172,7 @@
         
         <p>The goal of the Character Model for the World Wide Web is to facilitate use of the Web by all people, regardless of their language, script, writing system, or cultural conventions, in accordance with the <a href="http://www.w3.org/Consortium/mission"><cite>W3C goal of universal access</cite></a>. One basic prerequisite to achieve this goal is to be able to transmit and process the characters used around the world in a well-defined and well-understood way.</p>
         
-        <p class="note">This document builds on <cite>Character Model for the World Wide Web: Fundamentals</cite> [[!CHARMOD]]. Understanding the concepts in that document are important to being able to understand and apply this document successfully.</p>
+        <p class="note">This document builds on <cite>Character Model for the World Wide Web: Fundamentals</cite> [[CHARMOD]]. Understanding the concepts in that document are important to being able to understand and apply this document successfully.</p>
         
         <p>This part of the Character Model for the World Wide Web covers string 
 		matching—the process by which a specification or implementation defines 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/charmod-norm/pull/207.html" title="Last updated on Sep 18, 2020, 4:37 PM UTC (4c4d412)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/charmod-norm/207/3418f51...aphillips:4c4d412.html" title="Last updated on Sep 18, 2020, 4:37 PM UTC (4c4d412)">Diff</a>