### PR TITLE
Add CONTRIBUTORS.md page and add github actions to automatically update it

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -1,0 +1,30 @@
+name: Update Contributors List
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 0 * * *"  # Runs daily at midnight UTC
+  workflow_dispatch:  # Allows manual runs
+
+jobs:
+  update-contributors:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Generate Contributors List
+        uses: akhilmhdh/contributors-readme-action@v2.3.6
+        with:
+          use_contributors: "true"
+          readme_path: "CONTRIBUTORS.md"
+
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+          git add CONTRIBUTORS.md
+          git commit -m "Automated update of CONTRIBUTORS.md" || echo "No changes to commit"
+          git push

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,7 @@
+# Contributors
+
+Thanks to everyone who has contributed to this project!
+
+[![Contributors](https://contrib.rocks/image?repo=r12a/charmod-norm)](https://github.com/YOUR-USERNAME/YOUR-REPO/graphs/contributors)
+
+


### PR DESCRIPTION
This PR adds the contributor page to this repo. This PR also adds a GitHub Actions workflow to update CONTRIBUTORS.md automatically. It fetches all contributors and commits changes daily at midnight UTC. For this to work github action needs to be on if they are already not. 

Changes that need to be done by the repo owner are in the CONTRIBUTORS.md file. The `repo name` will need to be changed to the name of the repo this is in. The `username `will need to change to the owner of the repo.

```python
[![Contributors](https://contrib.rocks/image?repo=USERNAME/REPO-NAME)](https://github.com/YOUR-USERNAME/YOUR-REPO/graphs/contributors)
```